### PR TITLE
[codex] add contacts manager and notifications

### DIFF
--- a/.hermes/plans/2026-06-01_104144-settings-bg-bleedthrough.md
+++ b/.hermes/plans/2026-06-01_104144-settings-bg-bleedthrough.md
@@ -1,0 +1,69 @@
+# Fix: Settings panel visual bleed-through
+
+## Goal
+
+Fix two background bleed-through issues in the settings screen:
+
+1. **Vertical panel separator** — the gap between the "CATEGORIES" sidebar and the detail pane is just the base background showing through, with no visible divider.
+2. **AI model selector** — the text input fields for Model (OpenAI/Claude/Gemini/Ollama) blend into the surrounding form because their background matches the form row background.
+
+## Current context
+
+### Toky-Night theme colors (user's preferred theme)
+- `Bg`: `#1a1b26`
+- `Border`: `#414868`
+- `baseBg` (modal surface): `adjustLightness(Bg, 0.06)` ≈ `#1e1f2d`
+- `surfaceBg`: `adjustLightness(baseBg, 0.04)` ≈ `#202132`
+- `fieldBg`: `adjustLightness(baseBg, 0.08)` ≈ `#222438`
+- `border` (overlay): `#7aa2f7`
+
+### Issue 1: Vertical separator
+`settings.go:1249` — `viewSplit()` renders the separator as:
+```go
+separator := lipgloss.NewStyle().Background(chrome.baseBg).Render(" ")
+```
+This is a single space with the panel background color — no visible line at all. The left and right panes just touch invisibly through the gap.
+
+**Fix**: Replace with a `│` (vertical bar) character, styled with `chrome.border` foreground and `chrome.baseBg` background, width=1.
+
+**Alternative considered**: Using `lipgloss.JoinHorizontal` with actual borders on the panes — but that's more invasive and the panes don't currently use lipgloss borders. The single-character separator is minimal and consistent with the TUI aesthetic.
+
+### Issue 2: AI model selector text inputs
+`form_render.go:131-150` — `renderTextInput()` uses `chrome.baseBg` for both the style background and the truncateStyled background:
+```go
+view := truncateStyled(input.View(), width, chrome.baseBg)
+return lipgloss.NewStyle().
+    Background(chrome.baseBg).
+    Foreground(chrome.text).
+    Width(width).
+    Render(view)
+```
+
+`renderInsetControl()` (called by `addInput()`) also uses `chrome.baseBg`. The result: the Model text fields on the AI section have no visual demarcation — they look like background "showing through."
+
+Meanwhile, `renderSettingsPicker()` (used by Provider dropdown) correctly uses `chrome.surfaceBg` — so the provider picker looks distinct but the text fields don't.
+
+The compose panel (`compose.go:571`) uses `chrome.fieldBg` when a compose field is focused, as does the account manager. The `fieldBg` color is designed exactly for this purpose: subtly elevated background for input areas.
+
+**Fix**: Change `renderTextInput()` to use `chrome.fieldBg` instead of `chrome.baseBg` as the background color (both in the truncateStyled call and the style render).
+
+## Files to change
+
+| File | Lines | Change |
+|---|---|---|
+| `internal/ui/settings.go` | 1249 | `separator`: use `│` with `chrome.border` fg on `chrome.baseBg` bg, width=1 |
+| `internal/ui/form_render.go` | 144, 146 | `renderTextInput()`: change `chrome.baseBg` → `chrome.fieldBg` |
+
+## Test plan
+
+1. `go build ./...` — compilation check
+2. `go test ./internal/ui/...` — existing tests must pass
+3. Manual visual verification with `go run .`:
+   - Navigate to Settings → verify vertical separator is visible between CATEGORIES sidebar and detail pane
+   - Navigate to Settings → AI section → verify Model text inputs have a subtly distinct background from the surrounding form
+
+## Risks and open questions
+
+- `renderTextInput()` is used in **all** settings text inputs (not just AI model). Changing its background to `fieldBg` affects: Reading width, Browser command, Feed max body, Retro color fields, API key fields, Model fields, Ollama URL, Save path, and the Manual install command. All of them should benefit from a slightly elevated background — they all have the same "bg showing through" problem. This is a general improvement, not specific to the AI section.
+- The `fieldBg` for tokyo-night is `#222438` — already provides enough contrast against `#1e1f2d` (`baseBg`) to be visible.
+- Need to verify `truncateStyled` also passes the bg color correctly when the text overflows its box.

--- a/.hermes/plans/2026-06-01_111747-contacts-management.md
+++ b/.hermes/plans/2026-06-01_111747-contacts-management.md
@@ -1,0 +1,134 @@
+# Contacts: autocomplete management & pruning
+
+## Goal
+
+Improve the compose autocomplete address book — currently a raw `SELECT DISTINCT` over every From/To/CC field in all messages, which surfaces every automated email, newsletter, and one-off address with no way to prune or edit.
+
+## Current state
+
+| Component | File | What it does |
+|---|---|---|
+| `db.ListAddresses()` | `internal/db/messages.go:257` | `SELECT DISTINCT addr FROM (from_addr UNION to_addr UNION cc_addr)` over all messages |
+| `Model.loadAddressBookCmd()` | `internal/ui/sync.go:105` | Async tea.Cmd loads addresses on startup |
+| `AddressBookLoadedMsg` handler | (model.go) | Sets `m.addressBook` in model state |
+| `ComposeModel.SetAddressBook()` | `internal/ui/compose.go:108` | Sets autocomplete suggestions on To/CC text inputs |
+| Bubbletea textinput autocomplete | (bubbles dep) | Tab to accept suggestion, filtering as you type |
+
+**Problems:**
+1. No way to remove unwanted addresses from suggestions (newsletters, noreply@, one-offs)
+2. No way to add custom entries manually (favorite contacts not yet seen in messages)
+3. Addresses purely derived from message data — can't persist custom names/labels
+
+## Options
+
+---
+
+### Option 1: Hide-as-you-go (lightweight)
+
+Add a `hidden_addresses` table. When the user sees an unwanted suggestion in compose, a keybinding (e.g. `ctrl+d`) marks it as hidden. `ListAddresses` excludes hidden entries.
+
+**Schema:**
+```sql
+CREATE TABLE hidden_addresses (
+    addr TEXT PRIMARY KEY
+);
+```
+
+**Changes:**
+- `db.HideAddress(addr)` / `db.ListAddresses()` filters OUT addresses in `hidden_addresses`
+- `db.ListAddresses()` adds a LEFT JOIN or subquery to exclude hidden
+- Compose keybinding: `ctrl+d` on the To/CC field calls `db.HideAddress(ctx.CurrentSuggestion())`
+- Feedback: a brief status message "Hidden noreply@..." 
+
+**Pros:** Minimal changes. Addresses still auto-populate from messages. Simple UX — one keypress to dismiss.
+**Cons:** No way to undo/restore without SQL directly. No display names or favorites. Accidentally hiding an address means it's gone without a settings UI to view hidden list.
+
+---
+
+### Option 2: Address book table (structured)
+
+Add a proper `contacts` table with display name, address, and metadata. The auto-derived list becomes a seed, but the user can curate.
+
+**Schema:**
+```sql
+CREATE TABLE contacts (
+    id INTEGER PRIMARY KEY,
+    addr TEXT UNIQUE NOT NULL,
+    display_name TEXT DEFAULT '',
+    source TEXT DEFAULT 'auto',  -- 'auto' or 'manual'
+    use_count INTEGER DEFAULT 0,
+    last_used TEXT
+);
+```
+
+**Changes:**
+- `db.Migrate()`: create contacts table, seed from existing message addresses
+- `db.ListAddresses()`: queries contacts table instead of messages
+- `db.AddContact(addr, name)` / `db.RemoveContact(addr)`
+- On compose send: increment `use_count`, update `last_used`
+- Settings → a new "Contacts" section to view/edit/delete entries
+- Compose: keybinding (`ctrl+d`) to remove from suggestions with confirmation
+
+**Pros:** Full curation. Display names. Usage tracking enables smart sorting (most-used first). Can add contacts manually.
+**Cons:** More code. Migration from message-addresses to contacts table. Need a settings UI for viewing/editing contacts list.
+
+---
+
+### Option 3: Frequency-filtered auto-populate (smart defaults)
+
+Keep deriving from messages but only show addresses that appear ≥ N times or have been manually interacted with. Add a "dismiss" action to temporarily hide individual addresses.
+
+**Changes:**
+- `db.ListAddresses()`: add `GROUP BY addr HAVING COUNT(*) >= 2` or a `use_count` threshold
+- Add `dismissed_addresses` table for temporary hiding (cleared on restart or persistent)
+- Compose keybinding: `ctrl+d` to dismiss
+
+**Pros:** Filters out one-off addresses automatically without user action. Very little code.
+**Cons:** Still can't add custom entries or display names. New contacts with one email won't show initially. Threshold is a guess — what's "frequent" to one user isn't to another.
+
+---
+
+### Option 4: Hybrid (Option 1 + contact list in settings)
+
+Start with Option 1's `hidden_addresses` table for quick dismissal, plus a settings pane to view/manage the hidden list (un-hide individual addresses, see the full list).
+
+**Schema (same as Option 1):**
+```sql
+CREATE TABLE hidden_addresses (addr TEXT PRIMARY KEY);
+```
+
+**Changes (Option 1 + extras):**
+- All changes from Option 1
+- Settings → a new "ADDRESSES" section or an entry under ADVANCED
+- Settings pane: scrollable list of hidden addresses with an "Unhide" action per entry
+- Status bar message: "Hidden noreply@... (undo with ctrl+z or manage in Settings)"
+
+**Pros:** Same simplicity as Option 1, but adds discoverability and undo. No migration complexity.
+**Cons:** Still no display names or favorites. Just a hide/un-hide system.
+
+---
+
+## Recommendation
+
+**Option 4 (Hybrid)** is the sweet spot for this request. The user's primary pain point is "too many unwanted addresses" — a simple hide mechanism solves that immediately. Adding a settings view for the hidden list gives them control and the ability to undo mistakes. Option 2 is the "right" long-term solution but is a significantly larger feature that touches migration, a full settings screen, and compose entry tracking.
+
+If you want display names and favorites eventually, Option 2 can be built on top of Option 4 later — the `hidden_addresses` table becomes a flag in the contacts table.
+
+---
+
+## Files likely to change
+
+| File | Changes |
+|---|---|
+| `internal/db/messages.go` | Add `hidden_addresses` table in migration; modify `ListAddresses()` to filter hidden |
+| `internal/db/db.go` | Migration version bump if needed |
+| `internal/ui/compose.go` | Keybinding for hide action; access to db or model to call hide |
+| `internal/ui/model.go` | Wire addressBook into compose on open; handle hide events |
+| `internal/ui/settings.go` | New ADDRESSES section (or entry under ADVANCED) to view/manage hidden list |
+| `internal/ui/account_manager.go` | (maybe) `managerChrome` already covers settings rendering |
+
+## Tests
+
+- `ListAddresses()` with hidden addresses: verify they're excluded
+- Settings view: verify hidden addresses are listed
+- Unhide action: address reappears in autocomplete

--- a/.hermes/plans/2026-06-01_113945-bg-bleed-account-status.md
+++ b/.hermes/plans/2026-06-01_113945-bg-bleed-account-status.md
@@ -1,0 +1,30 @@
+# Fix: remaining bg bleed from Width()-based padding
+
+## Issue
+
+`Width(width).Render(text)` in lipgloss can leave unpadded gaps when ANSI-styled text is narrower than its visual width calculation. Already fixed hints and compose status/quote lines. Two more remain.
+
+## Remaining instances
+
+| File | Line | Context |
+|---|---|---|
+| `account_manager.go` | 958 | Account detail status line: `.Width(width).Padding(0,1).Render(status)` |
+| `account_manager.go` | 885 | Account list body wrapper (multi-line, probably fine but belt-and-suspenders) |
+| `account_manager.go` | 1180 | Edit-account form body wrapper (same) |
+
+## Fix
+
+Replace `Width(width).Render(text)` with explicit gap padding, same pattern as previous fixes:
+
+```go
+rendered := style.Render(text)
+if gap := width - lipgloss.Width(rendered); gap > 0 {
+    rendered += lipgloss.NewStyle().Background(bg).Render(strings.Repeat(" ", gap))
+}
+```
+
+Lines 885/1180 wrap multi-line bodies where individual rows are already full-width — skip those, they're safe.
+
+## Files
+
+- `internal/ui/account_manager.go` — line 958 only

--- a/go.mod
+++ b/go.mod
@@ -5,20 +5,23 @@ go 1.26.1
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/JohannesKaufmann/html-to-markdown v1.6.0
+	github.com/PuerkitoBio/goquery v1.9.2
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/emersion/go-imap/v2 v2.0.0-beta.8
 	github.com/emersion/go-message v0.18.2
+	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
+	github.com/emersion/go-vcard v0.0.0-20241024213814-c9703dde27ff
 	github.com/muesli/termenv v0.16.0
 	github.com/yuin/goldmark v1.7.1
+	golang.org/x/oauth2 v0.36.0
 	modernc.org/sqlite v1.48.0
 )
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
-	github.com/PuerkitoBio/goquery v1.9.2 // indirect
 	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -29,7 +32,6 @@ require (
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
@@ -43,7 +45,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	modernc.org/libc v1.70.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/emersion/go-message v0.18.2 h1:rl55SQdjd9oJcIoQNhubD2Acs1E6IzlZISRTK7
 github.com/emersion/go-message v0.18.2/go.mod h1:XpJyL70LwRvq2a8rVbHXikPgKj8+aI0kGdHlg16ibYA=
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 h1:oP4q0fw+fOSWn3DfFi4EXdT+B+gTtzx8GC9xsc26Znk=
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
+github.com/emersion/go-vcard v0.0.0-20241024213814-c9703dde27ff h1:4N8wnS3f1hNHSmFD5zgFkWCyA4L1kCDkImPAtK7D6tg=
+github.com/emersion/go-vcard v0.0.0-20241024213814-c9703dde27ff/go.mod h1:HMJKR5wlh/ziNp+sHEDV2ltblO4JD2+IdDOWtGcQBTM=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ type DisplayConfig struct {
 	ReadingWidth      int                `toml:"reading_width"`
 	ConfirmQuit       bool               `toml:"confirm_quit"`
 	ShowHeaders       bool               `toml:"show_headers"`
+	Notifications     bool               `toml:"notifications"`
 	Browser           string             `toml:"browser"`
 	Density           string             `toml:"density"`
 	VT52              RetroTerminalTweak `toml:"vt52"`
@@ -124,6 +125,7 @@ func DefaultConfig() Config {
 			Density:        "compact",
 			ConfirmQuit:    true,
 			ShowHeaders:    true,
+			Notifications:  true,
 		},
 		Updates: UpdatesConfig{
 			CheckOnStartup:     true,

--- a/internal/db/contacts.go
+++ b/internal/db/contacts.go
@@ -1,0 +1,168 @@
+package db
+
+import (
+	"net/mail"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Contact struct {
+	ID          int64
+	Addr        string
+	DisplayName string
+	Source      string
+	CreatedAt   time.Time
+}
+
+func normalizeAddress(raw string) (addr, name string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", ""
+	}
+	if a, err := mail.ParseAddress(raw); err == nil {
+		return strings.ToLower(strings.TrimSpace(a.Address)), strings.TrimSpace(a.Name)
+	}
+	if strings.Contains(raw, "@") && !strings.ContainsAny(raw, " <>") {
+		return strings.ToLower(raw), ""
+	}
+	return "", ""
+}
+
+func scanCuratedContacts(rows interface {
+	Next() bool
+	Scan(...any) error
+	Err() error
+}) ([]Contact, error) {
+	var out []Contact
+	for rows.Next() {
+		var c Contact
+		var createdAt int64
+		if err := rows.Scan(&c.ID, &c.Addr, &c.DisplayName, &c.Source, &createdAt); err != nil {
+			return out, err
+		}
+		if createdAt > 0 {
+			c.CreatedAt = time.Unix(createdAt, 0)
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func (db *DB) ListContacts() ([]Contact, error) {
+	rows, err := db.Query(`
+		SELECT id, addr, display_name, source, created_at
+		FROM contacts
+		ORDER BY (display_name = '') ASC, display_name COLLATE NOCASE, addr`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanCuratedContacts(rows)
+}
+
+func (db *DB) AddContact(rawAddr, rawName, source string) (int64, error) {
+	addr, parsedName := normalizeAddress(rawAddr)
+	if addr == "" {
+		return 0, nil
+	}
+	name := strings.TrimSpace(rawName)
+	if name == "" {
+		name = parsedName
+	}
+	if source == "" {
+		source = "manual"
+	}
+	now := time.Now().Unix()
+	_, err := db.Exec(`
+		INSERT INTO contacts (addr, display_name, source, created_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(addr) DO UPDATE SET
+			display_name = excluded.display_name,
+			source       = excluded.source`,
+		addr, name, source, now)
+	if err != nil {
+		return 0, err
+	}
+	var id int64
+	err = db.QueryRow(`SELECT id FROM contacts WHERE addr = ?`, addr).Scan(&id)
+	return id, err
+}
+
+func (db *DB) UpdateContact(id int64, rawAddr, rawName string) error {
+	addr, parsedName := normalizeAddress(rawAddr)
+	if addr == "" {
+		return nil
+	}
+	name := strings.TrimSpace(rawName)
+	if name == "" {
+		name = parsedName
+	}
+	_, err := db.Exec(`UPDATE contacts SET addr = ?, display_name = ? WHERE id = ?`, addr, name, id)
+	return err
+}
+
+func (db *DB) DeleteContact(id int64) error {
+	_, err := db.Exec(`DELETE FROM contacts WHERE id = ?`, id)
+	return err
+}
+
+func (db *DB) ContactAddresses() ([]string, error) {
+	contacts, err := db.ListContacts()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(contacts))
+	for _, c := range contacts {
+		if c.DisplayName != "" {
+			out = append(out, c.DisplayName+" <"+c.Addr+">")
+		} else {
+			out = append(out, c.Addr)
+		}
+	}
+	return out, nil
+}
+
+func (db *DB) SeenAddresses() ([]Contact, error) {
+	knownContacts, err := db.ListContacts()
+	if err != nil {
+		return nil, err
+	}
+	known := make(map[string]bool, len(knownContacts))
+	for _, c := range knownContacts {
+		known[c.Addr] = true
+	}
+
+	addrs, err := db.ListAddresses()
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]Contact)
+	for _, raw := range addrs {
+		addr, name := normalizeAddress(raw)
+		if addr == "" || known[addr] {
+			continue
+		}
+		if existing, ok := seen[addr]; ok {
+			if existing.DisplayName == "" && name != "" {
+				existing.DisplayName = name
+				seen[addr] = existing
+			}
+			continue
+		}
+		seen[addr] = Contact{Addr: addr, DisplayName: name, Source: "seen"}
+	}
+	out := make([]Contact, 0, len(seen))
+	for _, c := range seen {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		li := strings.ToLower(out[i].DisplayName)
+		lj := strings.ToLower(out[j].DisplayName)
+		if li == lj {
+			return out[i].Addr < out[j].Addr
+		}
+		return li < lj
+	})
+	return out, nil
+}

--- a/internal/db/contacts_test.go
+++ b/internal/db/contacts_test.go
@@ -1,0 +1,214 @@
+package db
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func newTestDB(t *testing.T) *DB {
+	t.Helper()
+	database, err := openSQLite(filepath.Join(t.TempDir(), "mail.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	if err := database.init(); err != nil {
+		t.Fatal(err)
+	}
+	return database
+}
+
+func TestAddContactUpsertAndNormalize(t *testing.T) {
+	d := newTestDB(t)
+	id, err := d.AddContact("Bob <BOB@Example.com>", "", "manual")
+	if err != nil || id == 0 {
+		t.Fatalf("AddContact: id=%d err=%v", id, err)
+	}
+	got, err := d.ListContacts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Addr != "bob@example.com" || got[0].DisplayName != "Bob" || got[0].Source != "manual" {
+		t.Fatalf("expected normalized bob, got %+v", got)
+	}
+
+	again, err := d.AddContact("bob@example.com", "Bobby", "vcard")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again != id {
+		t.Fatalf("expected upsert to return same id %d, got %d", id, again)
+	}
+	got, _ = d.ListContacts()
+	if len(got) != 1 || got[0].DisplayName != "Bobby" || got[0].Source != "vcard" {
+		t.Fatalf("expected single updated row, got %+v", got)
+	}
+}
+
+func TestListContactsOrderAndContactAddressesFormat(t *testing.T) {
+	d := newTestDB(t)
+	_, _ = d.AddContact("zed@example.com", "", "manual")
+	_, _ = d.AddContact("Amy <amy@example.com>", "", "manual")
+	_, _ = d.AddContact("bob@example.com", "Bob", "manual")
+
+	got, err := d.ListContacts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 contacts, got %+v", got)
+	}
+	if got[0].Addr != "amy@example.com" || got[1].Addr != "bob@example.com" || got[2].Addr != "zed@example.com" {
+		t.Fatalf("unexpected order: %+v", got)
+	}
+
+	addrs, err := d.ContactAddresses()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"Amy <amy@example.com>", "Bob <bob@example.com>", "zed@example.com"}
+	for i := range want {
+		if addrs[i] != want[i] {
+			t.Fatalf("addresses[%d] = %q, want %q; all=%v", i, addrs[i], want[i], addrs)
+		}
+	}
+}
+
+func TestUpdateAndDeleteContact(t *testing.T) {
+	d := newTestDB(t)
+	id, _ := d.AddContact("temp@example.com", "Temp", "manual")
+	if err := d.UpdateContact(id, "Perm <PERM@example.com>", ""); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := d.ListContacts()
+	if len(got) != 1 || got[0].Addr != "perm@example.com" || got[0].DisplayName != "Perm" {
+		t.Fatalf("update failed: %+v", got)
+	}
+	if err := d.DeleteContact(id); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := d.ListContacts(); len(got) != 0 {
+		t.Fatalf("delete failed: %+v", got)
+	}
+}
+
+func TestSeenAddressesDedupesAndExcludesContacts(t *testing.T) {
+	d := newTestDB(t)
+	accountID, _ := d.AddAccount("Acct", "")
+	mailboxID, _ := d.UpsertMailbox(Mailbox{AccountID: accountID, Name: "INBOX"})
+	_ = d.UpsertMessage(Message{
+		MailboxID: mailboxID,
+		UID:       1,
+		From:      "Carol <CAROL@example.com>",
+		To:        "Alice <alice@example.com>, bob@example.com",
+		CC:        "carol@example.com",
+	})
+	_ = d.UpsertMessage(Message{
+		MailboxID: mailboxID,
+		UID:       2,
+		From:      "Bob <BOB@example.com>",
+		To:        "dave@example.com",
+	})
+	_, _ = d.AddContact("alice@example.com", "Alice", "manual")
+
+	seen, err := d.SeenAddresses()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, c := range seen {
+		got = append(got, c.Addr+"|"+c.DisplayName)
+	}
+	want := map[string]bool{
+		"bob@example.com|Bob":     true,
+		"carol@example.com|Carol": true,
+		"dave@example.com|":       true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected seen addresses: %v", got)
+	}
+	for _, item := range got {
+		if !want[item] {
+			t.Fatalf("unexpected seen address %q in %v", item, got)
+		}
+	}
+}
+
+func TestInitMigratesLegacyAutoContactsToCuratedSchema(t *testing.T) {
+	database, err := openSQLite(filepath.Join(t.TempDir(), "mail.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	if _, err := database.Exec(`
+		CREATE TABLE contacts (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			addr         TEXT    NOT NULL UNIQUE,
+			display_name TEXT    NOT NULL DEFAULT '',
+			status       TEXT    NOT NULL DEFAULT 'pending',
+			source       TEXT    NOT NULL DEFAULT 'auto',
+			use_count    INTEGER NOT NULL DEFAULT 0,
+			last_used    INTEGER NOT NULL DEFAULT 0,
+			created_at   INTEGER NOT NULL DEFAULT 0
+		);
+		INSERT INTO contacts (addr, display_name, status, source, created_at) VALUES
+			('auto@example.com', 'Auto', 'pending', 'auto', 100),
+			('manual@example.com', 'Manual', 'approved', 'manual', 200),
+			('vcard@example.com', 'VCard', 'approved', 'vcard', 300);
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := database.init(); err != nil {
+		t.Fatal(err)
+	}
+
+	cols := contactTestColumns(t, database)
+	for _, legacy := range []string{"status", "use_count", "last_used"} {
+		if cols[legacy] {
+			t.Fatalf("legacy column %q still exists after migration: %v", legacy, cols)
+		}
+	}
+
+	got, err := database.ListContacts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected only curated contacts, got %+v", got)
+	}
+	for _, c := range got {
+		if c.Addr == "auto@example.com" {
+			t.Fatalf("auto-captured contact survived migration: %+v", got)
+		}
+	}
+}
+
+func contactTestColumns(t *testing.T, database *DB) map[string]bool {
+	t.Helper()
+	rows, err := database.Query(`PRAGMA table_info(contacts)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	cols := map[string]bool{}
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			t.Fatal(err)
+		}
+		cols[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return cols
+}

--- a/internal/db/contacts_vcard.go
+++ b/internal/db/contacts_vcard.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"io"
+	"strings"
+
+	"github.com/emersion/go-vcard"
+)
+
+func (db *DB) ImportVCard(r io.Reader) (int, error) {
+	dec := vcard.NewDecoder(r)
+	added := 0
+	for {
+		card, err := dec.Decode()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return added, err
+		}
+		name := vcardDisplayName(card)
+		for _, field := range card[vcard.FieldEmail] {
+			if field == nil || strings.TrimSpace(field.Value) == "" {
+				continue
+			}
+			id, err := db.AddContact(field.Value, name, "vcard")
+			if err != nil {
+				return added, err
+			}
+			if id != 0 {
+				added++
+			}
+		}
+	}
+	return added, nil
+}
+
+func vcardDisplayName(card vcard.Card) string {
+	if name := strings.TrimSpace(card.PreferredValue(vcard.FieldFormattedName)); name != "" {
+		return name
+	}
+	n := card.Name()
+	if n == nil {
+		return ""
+	}
+	parts := []string{
+		strings.TrimSpace(n.HonorificPrefix),
+		strings.TrimSpace(n.GivenName),
+		strings.TrimSpace(n.AdditionalName),
+		strings.TrimSpace(n.FamilyName),
+		strings.TrimSpace(n.HonorificSuffix),
+	}
+	var kept []string
+	for _, part := range parts {
+		if part != "" {
+			kept = append(kept, part)
+		}
+	}
+	return strings.Join(kept, " ")
+}
+
+func (db *DB) ExportVCard(w io.Writer) error {
+	contacts, err := db.ListContacts()
+	if err != nil {
+		return err
+	}
+	enc := vcard.NewEncoder(w)
+	for _, c := range contacts {
+		card := make(vcard.Card)
+		name := c.DisplayName
+		if name == "" {
+			name = c.Addr
+		}
+		card.SetValue(vcard.FieldFormattedName, name)
+		card.SetValue(vcard.FieldEmail, c.Addr)
+		vcard.ToV4(card)
+		if err := enc.Encode(card); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/db/contacts_vcard_test.go
+++ b/internal/db/contacts_vcard_test.go
@@ -1,0 +1,84 @@
+package db
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVCardRoundTrip(t *testing.T) {
+	d := newTestDB(t)
+	_, _ = d.AddContact("amy@example.com", "Amy Smith", "manual")
+	_, _ = d.AddContact("bob@example.com", "", "manual")
+
+	var buf bytes.Buffer
+	if err := d.ExportVCard(&buf); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if !strings.Contains(buf.String(), "amy@example.com") || !strings.Contains(buf.String(), "Amy Smith") {
+		t.Fatalf("export missing data:\n%s", buf.String())
+	}
+
+	d2 := newTestDB(t)
+	n, err := d2.ImportVCard(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 imported, got %d", n)
+	}
+	got, _ := d2.ListContacts()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 contacts after import, got %+v", got)
+	}
+}
+
+func TestImportVCardMultipleEmails(t *testing.T) {
+	const card = "BEGIN:VCARD\r\n" +
+		"VERSION:4.0\r\n" +
+		"FN:Multi Person\r\n" +
+		"EMAIL:one@example.com\r\n" +
+		"EMAIL:two@example.com\r\n" +
+		"END:VCARD\r\n"
+	d := newTestDB(t)
+	n, err := d.ImportVCard(strings.NewReader(card))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected both emails imported, got %d", n)
+	}
+	got, _ := d.ListContacts()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 contacts, got %+v", got)
+	}
+	for _, c := range got {
+		if c.DisplayName != "Multi Person" || c.Source != "vcard" {
+			t.Fatalf("expected shared vcard name/source, got %+v", c)
+		}
+	}
+}
+
+func TestImportVCardStructuredNameFallback(t *testing.T) {
+	const card = "BEGIN:VCARD\r\n" +
+		"VERSION:4.0\r\n" +
+		"N:Doe;Jane;;;\r\n" +
+		"EMAIL:jane@example.com\r\n" +
+		"END:VCARD\r\n"
+	d := newTestDB(t)
+	if _, err := d.ImportVCard(strings.NewReader(card)); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	got, _ := d.ListContacts()
+	if len(got) != 1 || got[0].DisplayName != "Jane Doe" {
+		t.Fatalf("expected structured name fallback, got %+v", got)
+	}
+}
+
+func TestImportVCardMalformed(t *testing.T) {
+	d := newTestDB(t)
+	_, err := d.ImportVCard(strings.NewReader("BEGIN:VCARD\r\nFN:Broken\r\n"))
+	if err == nil {
+		t.Fatal("expected error for malformed vCard")
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -48,7 +48,10 @@ func (db *DB) init() error {
 			return err
 		}
 	}
-	return db.migrate()
+	if err := db.migrate(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (db *DB) migrate() error {
@@ -110,6 +113,14 @@ func (db *DB) migrate() error {
 			key   TEXT PRIMARY KEY,
 			value TEXT NOT NULL DEFAULT ''
 		);
+
+		CREATE TABLE IF NOT EXISTS contacts (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			addr         TEXT    NOT NULL UNIQUE,
+			display_name TEXT    NOT NULL DEFAULT '',
+			source       TEXT    NOT NULL DEFAULT 'manual',
+			created_at   INTEGER NOT NULL DEFAULT 0
+		);
 	`)
 	if err != nil {
 		return err
@@ -117,7 +128,68 @@ func (db *DB) migrate() error {
 	// Migrations: add columns that may not exist on older databases.
 	// SQLite error on duplicate column is silently ignored.
 	db.Exec(`ALTER TABLE messages ADD COLUMN headers TEXT NOT NULL DEFAULT ''`) //nolint:errcheck
+	if err := db.migrateContactsToCuratedSchema(); err != nil {
+		return err
+	}
 	return nil
+}
+
+func (db *DB) migrateContactsToCuratedSchema() error {
+	rows, err := db.Query(`PRAGMA table_info(contacts)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	columns := map[string]bool{}
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		columns[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if !columns["status"] && !columns["use_count"] && !columns["last_used"] {
+		return nil
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.Exec(`
+		CREATE TABLE contacts_curated_new (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			addr         TEXT    NOT NULL UNIQUE,
+			display_name TEXT    NOT NULL DEFAULT '',
+			source       TEXT    NOT NULL DEFAULT 'manual',
+			created_at   INTEGER NOT NULL DEFAULT 0
+		)`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`
+		INSERT OR IGNORE INTO contacts_curated_new (id, addr, display_name, source, created_at)
+		SELECT id, addr, display_name, source, created_at
+		FROM contacts
+		WHERE source IN ('manual', 'vcard', 'carddav')`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DROP TABLE contacts`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`ALTER TABLE contacts_curated_new RENAME TO contacts`); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // GetSetting retrieves a UI setting value by key.

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -186,6 +186,15 @@ func (db *DB) UpsertMessage(m Message) error {
 	return nil
 }
 
+// MessageExists reports whether a message with the given mailbox/uid is already
+// stored. Used to distinguish genuinely-new mail from re-fetches: IMAP SINCE is
+// date-granular, so a poll re-downloads messages we already hold.
+func (db *DB) MessageExists(mailboxID int64, uid uint32) (bool, error) {
+	var n int
+	err := db.QueryRow(`SELECT COUNT(1) FROM messages WHERE mailbox_id = ? AND uid = ?`, mailboxID, uid).Scan(&n)
+	return n > 0, err
+}
+
 func (db *DB) MarkRead(id int64, read bool) error {
 	v := 0
 	if read {

--- a/internal/ui/account_manager_model_test.go
+++ b/internal/ui/account_manager_model_test.go
@@ -420,7 +420,7 @@ func TestStoreFetchedMessagesAssignsMailboxID(t *testing.T) {
 		t.Fatalf("UpsertMailbox: %v", err)
 	}
 
-	newCount, err := storeFetchedMessages(database, mailboxID, []db.Message{{
+	newMsgs, err := storeFetchedMessages(database, mailboxID, []db.Message{{
 		UID:     42,
 		Subject: "Hello",
 		Date:    time.Unix(1700000000, 0),
@@ -428,8 +428,8 @@ func TestStoreFetchedMessagesAssignsMailboxID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("storeFetchedMessages: %v", err)
 	}
-	if newCount != 1 {
-		t.Fatalf("expected one unread message, got %d", newCount)
+	if len(newMsgs) != 1 {
+		t.Fatalf("expected one unread message, got %d", len(newMsgs))
 	}
 
 	messages, err := database.ListMessages(mailboxID)

--- a/internal/ui/compose.go
+++ b/internal/ui/compose.go
@@ -560,7 +560,10 @@ func sendMessageCmd(acfg config.AccountConfig, msg smtp.OutgoingMessage) tea.Cmd
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		err := smtp.Send(ctx, acfg, msg)
-		return MessageSentMsg{Err: err}
+		if err != nil {
+			return MessageSentMsg{Err: err}
+		}
+		return MessageSentMsg{}
 	}
 }
 
@@ -646,11 +649,14 @@ func renderComposePanelRow(ti textinput.Model, label string, focused bool, width
 		bg = chrome.fieldBg
 		labelFg = chrome.text
 	}
-	marker := lipgloss.NewStyle().Background(chrome.baseBg).Width(2).Render(" ")
+	// Marker + label sit on the panel background (surfaceBg) so To/CC/Subject match
+	// the RECIPIENTS/MESSAGE panel and the From row. Only the input cell shifts to
+	// fieldBg on focus.
+	marker := lipgloss.NewStyle().Background(chrome.surfaceBg).Width(2).Render(" ")
 	if focused {
-		marker = lipgloss.NewStyle().Background(chrome.baseBg).Foreground(chrome.accent).Bold(true).Width(2).Render(" >")
+		marker = lipgloss.NewStyle().Background(chrome.surfaceBg).Foreground(chrome.accent).Bold(true).Width(2).Render(" >")
 	}
-	labelCell := lipgloss.NewStyle().Background(chrome.baseBg).Foreground(labelFg).Width(labelW).Render(truncate(label, max(1, labelW-1)))
+	labelCell := lipgloss.NewStyle().Background(chrome.surfaceBg).Foreground(labelFg).Width(labelW).Render(truncate(label, max(1, labelW-1)))
 	ti.Width = ctrlW
 	ti.Prompt = ""
 	ti.PromptStyle = lipgloss.NewStyle().Background(bg).Foreground(chrome.accent)
@@ -658,11 +664,13 @@ func renderComposePanelRow(ti textinput.Model, label string, focused bool, width
 	ti.PlaceholderStyle = lipgloss.NewStyle().Background(bg).Foreground(chrome.muted)
 	ti.Cursor.Style = lipgloss.NewStyle().Background(chrome.accent).Foreground(contrastFg(chrome.accent))
 	raw := inputViewWithCursor(ti, focused)
-	wrapped := lipgloss.NewStyle().Background(bg).MaxWidth(ctrlW).Render(raw)
-	if gap := ctrlW - lipgloss.Width(wrapped); gap > 0 {
-		wrapped += lipgloss.NewStyle().Background(bg).Render(strings.Repeat(" ", gap))
-	}
-	ctrlCell := lipgloss.NewStyle().Background(bg).Foreground(chrome.text).Render(wrapped)
+	// bubbles pads the placeholder/value out to ti.Width with *unstyled* spaces
+	// (textinput.placeholderView), which leak the terminal's default background to
+	// the right of the hint. Trim that bare padding — styled cells (the block cursor,
+	// styled text) end in a reset SGR and survive TrimRight — then refill via
+	// padStyled so every gap cell carries bg.
+	raw = strings.TrimRight(raw, " ")
+	ctrlCell := lipgloss.NewStyle().Background(bg).Foreground(chrome.text).Render(padStyled(raw, ctrlW, bg))
 	return marker + labelCell + ctrlCell
 }
 

--- a/internal/ui/contact_manager.go
+++ b/internal/ui/contact_manager.go
@@ -1,0 +1,813 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/allisonhere/tide/internal/db"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type cmMode int
+
+const (
+	cmList cmMode = iota
+	cmAdd
+	cmEdit
+	cmConfirmDelete
+	cmPickSeen
+	cmPickFile
+)
+
+type ContactManager struct {
+	db *db.DB
+
+	contacts []db.Contact
+	cursor   int
+	marked   map[int]bool
+	mode     cmMode
+
+	nameInput  textinput.Model
+	emailInput textinput.Model
+	focusEmail bool
+	editID     int64
+
+	seen       []db.Contact
+	filter     textinput.Model
+	pickCursor int
+	pickMarked map[int]bool
+
+	filePicker filePicker
+	importing  bool
+	statusMsg  string
+	isErr      bool
+}
+
+func NewContactManager(database *db.DB) ContactManager {
+	cm := ContactManager{
+		db:         database,
+		marked:     map[int]bool{},
+		pickMarked: map[int]bool{},
+	}
+	cm.nameInput = newAMInput("Display name (optional)", false)
+	cm.emailInput = newAMInput("you@example.com", false)
+	cm.filter = newAMInput("filter seen mail", false)
+	cm.reload()
+	return cm
+}
+
+func (cm *ContactManager) reload() {
+	cm.contacts, _ = cm.db.ListContacts()
+	cm.clampCursor()
+}
+
+func (cm *ContactManager) clampCursor() {
+	if cm.cursor < 0 {
+		cm.cursor = 0
+	}
+	if len(cm.contacts) == 0 {
+		cm.cursor = 0
+		return
+	}
+	if cm.cursor >= len(cm.contacts) {
+		cm.cursor = len(cm.contacts) - 1
+	}
+}
+
+func (cm *ContactManager) selected() (db.Contact, bool) {
+	if cm.cursor < 0 || cm.cursor >= len(cm.contacts) {
+		return db.Contact{}, false
+	}
+	return cm.contacts[cm.cursor], true
+}
+
+func (cm *ContactManager) setStatus(msg string, isErr bool) {
+	cm.statusMsg = msg
+	cm.isErr = isErr
+}
+
+func (cm *ContactManager) clearMarks() {
+	cm.marked = map[int]bool{}
+}
+
+func (cm ContactManager) targetIndexes() []int {
+	var indexes []int
+	for i := range cm.contacts {
+		if cm.marked[i] {
+			indexes = append(indexes, i)
+		}
+	}
+	if len(indexes) > 0 {
+		return indexes
+	}
+	if _, ok := cm.selected(); ok {
+		return []int{cm.cursor}
+	}
+	return nil
+}
+
+func (cm *ContactManager) toggleMarkAdvance() {
+	if len(cm.contacts) == 0 {
+		return
+	}
+	if cm.marked[cm.cursor] {
+		delete(cm.marked, cm.cursor)
+	} else {
+		cm.marked[cm.cursor] = true
+	}
+	if cm.cursor < len(cm.contacts)-1 {
+		cm.cursor++
+	}
+	if len(cm.marked) > 0 {
+		cm.setStatus(fmt.Sprintf("%d selected", len(cm.marked)), false)
+	} else {
+		cm.statusMsg = ""
+	}
+}
+
+func (cm ContactManager) Update(msg tea.Msg, keys KeyMap) (ContactManager, tea.Cmd, bool) {
+	switch cm.mode {
+	case cmAdd, cmEdit:
+		return cm.updateForm(msg, keys)
+	case cmConfirmDelete:
+		return cm.updateConfirmDelete(msg, keys)
+	case cmPickSeen:
+		return cm.updatePicker(msg, keys)
+	case cmPickFile:
+		return cm.updateFilePicker(msg, keys)
+	default:
+		return cm.updateList(msg, keys)
+	}
+}
+
+func (cm ContactManager) updateList(msg tea.Msg, keys KeyMap) (ContactManager, tea.Cmd, bool) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return cm, nil, false
+	}
+	switch {
+	case keyMatches(km, keys.Cancel), keyMatches(km, keys.Back):
+		return cm, nil, true
+	case keyMatches(km, keys.Up):
+		if cm.cursor > 0 {
+			cm.cursor--
+		}
+	case keyMatches(km, keys.Down):
+		if cm.cursor < len(cm.contacts)-1 {
+			cm.cursor++
+		}
+	case keyMatches(km, keys.Space):
+		cm.toggleMarkAdvance()
+	case km.String() == "n":
+		cm.beginAdd()
+	case keyMatches(km, keys.Edit):
+		cm.beginEdit()
+	case keyMatches(km, keys.Delete):
+		if len(cm.targetIndexes()) > 0 {
+			cm.mode = cmConfirmDelete
+		}
+	case km.String() == "f":
+		cm.beginPicker()
+	case km.String() == "i":
+		cm.beginFilePicker(true)
+	case km.String() == "x":
+		cm.beginFilePicker(false)
+	}
+	return cm, nil, false
+}
+
+func (cm *ContactManager) beginAdd() {
+	cm.mode = cmAdd
+	cm.editID = 0
+	cm.nameInput.Reset()
+	cm.emailInput.Reset()
+	cm.focusEmail = false
+	cm.nameInput.Focus()
+	cm.emailInput.Blur()
+	cm.statusMsg = ""
+}
+
+func (cm *ContactManager) beginEdit() {
+	c, ok := cm.selected()
+	if !ok {
+		return
+	}
+	cm.mode = cmEdit
+	cm.editID = c.ID
+	cm.nameInput.SetValue(c.DisplayName)
+	cm.emailInput.SetValue(c.Addr)
+	cm.focusEmail = false
+	cm.nameInput.Focus()
+	cm.emailInput.Blur()
+	cm.statusMsg = ""
+}
+
+func (cm *ContactManager) beginPicker() {
+	cm.mode = cmPickSeen
+	cm.seen, _ = cm.db.SeenAddresses()
+	cm.filter.Reset()
+	cm.filter.Focus()
+	cm.pickCursor = 0
+	cm.pickMarked = map[int]bool{}
+	cm.statusMsg = ""
+}
+
+func (cm *ContactManager) beginFilePicker(importing bool) {
+	cm.mode = cmPickFile
+	cm.importing = importing
+	cm.statusMsg = ""
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		cm.setStatus("home dir: "+err.Error(), true)
+		return
+	}
+	if !importing {
+		if downloads := filepath.Join(dir, "Downloads"); dirExists(downloads) {
+			dir = downloads
+		}
+	}
+	cm.openContactFilePicker(dir)
+}
+
+func (cm ContactManager) updateForm(msg tea.Msg, keys KeyMap) (ContactManager, tea.Cmd, bool) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		var cmd tea.Cmd
+		if cm.focusEmail {
+			cm.emailInput, cmd = cm.emailInput.Update(msg)
+		} else {
+			cm.nameInput, cmd = cm.nameInput.Update(msg)
+		}
+		return cm, cmd, false
+	}
+	switch {
+	case keyMatches(km, keys.Cancel), keyMatches(km, keys.Back):
+		cm.mode = cmList
+		cm.statusMsg = ""
+		return cm, nil, false
+	case keyMatches(km, keys.Tab), keyMatches(km, keys.Up), keyMatches(km, keys.Down):
+		cm.focusEmail = !cm.focusEmail
+		if cm.focusEmail {
+			cm.nameInput.Blur()
+			cm.emailInput.Focus()
+		} else {
+			cm.emailInput.Blur()
+			cm.nameInput.Focus()
+		}
+		return cm, nil, false
+	case keyMatches(km, keys.Enter):
+		return cm.submitForm(), nil, false
+	}
+	var cmd tea.Cmd
+	if cm.focusEmail {
+		cm.emailInput, cmd = cm.emailInput.Update(msg)
+	} else {
+		cm.nameInput, cmd = cm.nameInput.Update(msg)
+	}
+	return cm, cmd, false
+}
+
+func (cm ContactManager) submitForm() ContactManager {
+	addr := strings.TrimSpace(cm.emailInput.Value())
+	name := strings.TrimSpace(cm.nameInput.Value())
+	if addr == "" {
+		cm.setStatus("address is required", true)
+		return cm
+	}
+	if cm.mode == cmEdit && cm.editID != 0 {
+		if err := cm.db.UpdateContact(cm.editID, addr, name); err != nil {
+			cm.setStatus("save failed: "+err.Error(), true)
+			return cm
+		}
+		cm.setStatus("updated "+addr, false)
+	} else {
+		if _, err := cm.db.AddContact(addr, name, "manual"); err != nil {
+			cm.setStatus("save failed: "+err.Error(), true)
+			return cm
+		}
+		cm.setStatus("added "+addr, false)
+	}
+	cm.mode = cmList
+	cm.reload()
+	return cm
+}
+
+func (cm ContactManager) updateConfirmDelete(msg tea.Msg, keys KeyMap) (ContactManager, tea.Cmd, bool) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return cm, nil, false
+	}
+	switch {
+	case keyMatches(km, keys.Yes):
+		indexes := cm.targetIndexes()
+		for _, i := range indexes {
+			if i >= 0 && i < len(cm.contacts) {
+				if err := cm.db.DeleteContact(cm.contacts[i].ID); err != nil {
+					cm.setStatus("delete failed: "+err.Error(), true)
+					break
+				}
+			}
+		}
+		if cm.statusMsg == "" || !cm.isErr {
+			cm.setStatus(fmt.Sprintf("deleted %d contact(s)", len(indexes)), false)
+		}
+		cm.clearMarks()
+		cm.mode = cmList
+		cm.reload()
+	case keyMatches(km, keys.No), keyMatches(km, keys.Cancel), keyMatches(km, keys.Back):
+		cm.mode = cmList
+	}
+	return cm, nil, false
+}
+
+func (cm ContactManager) filteredSeen() []db.Contact {
+	q := strings.ToLower(strings.TrimSpace(cm.filter.Value()))
+	if q == "" {
+		return cm.seen
+	}
+	out := make([]db.Contact, 0, len(cm.seen))
+	for _, c := range cm.seen {
+		haystack := strings.ToLower(c.DisplayName + " " + c.Addr)
+		if strings.Contains(haystack, q) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func (cm *ContactManager) clampPickCursor(filtered []db.Contact) {
+	if cm.pickCursor < 0 {
+		cm.pickCursor = 0
+	}
+	if len(filtered) == 0 {
+		cm.pickCursor = 0
+		return
+	}
+	if cm.pickCursor >= len(filtered) {
+		cm.pickCursor = len(filtered) - 1
+	}
+}
+
+func (cm *ContactManager) togglePickMarkAdvance(filtered []db.Contact) {
+	if len(filtered) == 0 {
+		return
+	}
+	c := filtered[cm.pickCursor]
+	idx := cm.seenIndex(c)
+	if idx < 0 {
+		return
+	}
+	if cm.pickMarked[idx] {
+		delete(cm.pickMarked, idx)
+	} else {
+		cm.pickMarked[idx] = true
+	}
+	if cm.pickCursor < len(filtered)-1 {
+		cm.pickCursor++
+	}
+	if len(cm.pickMarked) > 0 {
+		cm.setStatus(fmt.Sprintf("%d selected", len(cm.pickMarked)), false)
+	} else {
+		cm.statusMsg = ""
+	}
+}
+
+func (cm ContactManager) seenIndex(contact db.Contact) int {
+	for i, c := range cm.seen {
+		if c.Addr == contact.Addr {
+			return i
+		}
+	}
+	return -1
+}
+
+func (cm ContactManager) updatePicker(msg tea.Msg, keys KeyMap) (ContactManager, tea.Cmd, bool) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		var cmd tea.Cmd
+		cm.filter, cmd = cm.filter.Update(msg)
+		cm.clampPickCursor(cm.filteredSeen())
+		return cm, cmd, false
+	}
+	switch {
+	case keyMatches(km, keys.Cancel), keyMatches(km, keys.Back):
+		cm.mode = cmList
+		cm.statusMsg = ""
+		return cm, nil, false
+	case keyMatches(km, keys.Up):
+		if cm.pickCursor > 0 {
+			cm.pickCursor--
+		}
+		return cm, nil, false
+	case keyMatches(km, keys.Down):
+		filtered := cm.filteredSeen()
+		if cm.pickCursor < len(filtered)-1 {
+			cm.pickCursor++
+		}
+		return cm, nil, false
+	case keyMatches(km, keys.Space):
+		cm.togglePickMarkAdvance(cm.filteredSeen())
+		return cm, nil, false
+	case keyMatches(km, keys.Enter), km.String() == "a":
+		return cm.addPickedContacts(), nil, false
+	}
+	var cmd tea.Cmd
+	cm.filter, cmd = cm.filter.Update(msg)
+	cm.clampPickCursor(cm.filteredSeen())
+	return cm, cmd, false
+}
+
+func (cm ContactManager) addPickedContacts() ContactManager {
+	filtered := cm.filteredSeen()
+	var picks []db.Contact
+	for idx := range cm.pickMarked {
+		if idx >= 0 && idx < len(cm.seen) {
+			picks = append(picks, cm.seen[idx])
+		}
+	}
+	if len(picks) == 0 && len(filtered) > 0 {
+		picks = []db.Contact{filtered[cm.pickCursor]}
+	}
+	for _, c := range picks {
+		if _, err := cm.db.AddContact(c.Addr, c.DisplayName, "manual"); err != nil {
+			cm.setStatus("add failed: "+err.Error(), true)
+			return cm
+		}
+	}
+	cm.mode = cmList
+	cm.pickMarked = map[int]bool{}
+	cm.reload()
+	cm.setStatus(fmt.Sprintf("added %d contact(s)", len(picks)), false)
+	return cm
+}
+
+func (cm *ContactManager) openContactFilePicker(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		cm.setStatus("pick: "+err.Error(), true)
+		cm.filePicker.active = false
+		return
+	}
+
+	var fe []fileEntry
+	if !cm.importing {
+		fe = append(fe, fileEntry{name: "✓ select this folder", isDir: false, size: 0})
+	}
+	if dir != "/" {
+		fe = append(fe, fileEntry{name: "..", isDir: true})
+	}
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		fe = append(fe, fileEntry{name: entry.Name(), isDir: entry.IsDir(), size: info.Size()})
+	}
+	sort.Slice(fe, func(i, j int) bool {
+		if fe[i].name == "✓ select this folder" {
+			return true
+		}
+		if fe[j].name == "✓ select this folder" {
+			return false
+		}
+		if fe[i].isDir != fe[j].isDir {
+			return fe[i].isDir
+		}
+		return strings.ToLower(fe[i].name) < strings.ToLower(fe[j].name)
+	})
+	cm.filePicker.currentDir = dir
+	cm.filePicker.entries = fe
+	cm.filePicker.cursor = 0
+	cm.filePicker.active = true
+}
+
+func (cm ContactManager) updateFilePicker(msg tea.Msg, keys KeyMap) (ContactManager, tea.Cmd, bool) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return cm, nil, false
+	}
+	switch {
+	case keyMatches(km, keys.Cancel), keyMatches(km, keys.Back):
+		cm.mode = cmList
+		cm.statusMsg = ""
+		return cm, nil, false
+	case keyMatches(km, keys.Up):
+		if cm.filePicker.cursor > 0 {
+			cm.filePicker.cursor--
+		}
+		return cm, nil, false
+	case keyMatches(km, keys.Down):
+		if cm.filePicker.cursor < len(cm.filePicker.entries)-1 {
+			cm.filePicker.cursor++
+		}
+		return cm, nil, false
+	case keyMatches(km, keys.Left):
+		cm.openContactFilePicker(filepath.Dir(cm.filePicker.currentDir))
+		return cm, nil, false
+	case keyMatches(km, keys.Enter):
+		return cm.confirmFilePicker(), nil, false
+	}
+	if len(km.String()) == 1 && ((km.String() >= "a" && km.String() <= "z") || (km.String() >= "A" && km.String() <= "Z")) {
+		lower := strings.ToLower(km.String())
+		for i, entry := range cm.filePicker.entries {
+			if strings.HasPrefix(strings.ToLower(entry.name), lower) {
+				cm.filePicker.cursor = i
+				break
+			}
+		}
+	}
+	return cm, nil, false
+}
+
+func (cm ContactManager) confirmFilePicker() ContactManager {
+	if cm.filePicker.cursor < 0 || cm.filePicker.cursor >= len(cm.filePicker.entries) {
+		return cm
+	}
+	entry := cm.filePicker.entries[cm.filePicker.cursor]
+	if entry.isDir {
+		if entry.name == ".." {
+			cm.openContactFilePicker(filepath.Dir(cm.filePicker.currentDir))
+		} else {
+			cm.openContactFilePicker(filepath.Join(cm.filePicker.currentDir, entry.name))
+		}
+		return cm
+	}
+	if cm.importing {
+		path := filepath.Join(cm.filePicker.currentDir, entry.name)
+		f, err := os.Open(path)
+		if err != nil {
+			cm.setStatus("open failed: "+err.Error(), true)
+			return cm
+		}
+		defer f.Close()
+		n, err := cm.db.ImportVCard(f)
+		if err != nil {
+			cm.setStatus("import failed: "+err.Error(), true)
+			return cm
+		}
+		cm.mode = cmList
+		cm.reload()
+		cm.setStatus(fmt.Sprintf("imported %d contacts", n), false)
+		return cm
+	}
+	path := filepath.Join(cm.filePicker.currentDir, "contacts.vcf")
+	f, err := os.Create(path)
+	if err != nil {
+		cm.setStatus("create failed: "+err.Error(), true)
+		return cm
+	}
+	defer f.Close()
+	if err := cm.db.ExportVCard(f); err != nil {
+		cm.setStatus("export failed: "+err.Error(), true)
+		return cm
+	}
+	cm.mode = cmList
+	cm.setStatus(fmt.Sprintf("exported %d contacts to %s", len(cm.contacts), path), false)
+	return cm
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func (cm ContactManager) View(width, height int, styles Styles) string {
+	chrome := newManagerChrome(width, styles.Theme, styles.PlainUI)
+	switch cm.mode {
+	case cmAdd:
+		return cm.viewForm(width, height, chrome, "ADD CONTACT")
+	case cmEdit:
+		return cm.viewForm(width, height, chrome, "EDIT CONTACT")
+	case cmConfirmDelete:
+		return cm.viewConfirmDelete(width, chrome)
+	case cmPickSeen:
+		return cm.viewPicker(width, height, chrome, styles)
+	case cmPickFile:
+		return cm.viewFilePicker(width, height, chrome)
+	default:
+		return cm.viewList(width, height, chrome, styles)
+	}
+}
+
+func (cm ContactManager) viewList(width, height int, chrome managerChrome, styles Styles) string {
+	header := renderManagerHeader("CONTACTS", width, chrome)
+	lines := make([]string, 0, max(1, len(cm.contacts)))
+	anchor := 0
+	if len(cm.contacts) == 0 {
+		lines = append(lines, lipgloss.NewStyle().Background(chrome.baseBg).Foreground(chrome.muted).Width(width).Padding(0, 1).Render("No contacts."))
+	} else {
+		for i, c := range cm.contacts {
+			selected := i == cm.cursor
+			if selected {
+				anchor = i
+			}
+			lines = append(lines, cm.renderContactRow(width, chrome, styles, c, i, selected))
+		}
+	}
+	bodyH := max(1, height-lipgloss.Height(header)-3)
+	offset := settingsScrollOffset(len(lines), anchor, bodyH)
+	end := min(len(lines), offset+bodyH)
+	body := clampView(
+		lipgloss.NewStyle().Background(chrome.baseBg).Width(width).Render(strings.Join(lines[offset:end], "\n")),
+		width, bodyH, chrome.baseBg,
+	)
+	parts := []string{header, body}
+	if status := cm.statusLine(width, chrome); status != "" {
+		parts = append(parts, status)
+	}
+	parts = append(parts, renderManagerActionGroups(width, chrome,
+		[]string{"space", "select", "n", "new", "f", "from mail", "i", "import", "x", "export"},
+		[]string{"e", "edit", "d", "delete", "esc", "close"},
+	))
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+func (cm ContactManager) renderContactRow(width int, chrome managerChrome, styles Styles, c db.Contact, index int, selected bool) string {
+	label := c.Addr
+	if c.DisplayName != "" {
+		label = fmt.Sprintf("%s  <%s>", c.DisplayName, c.Addr)
+	}
+	mark := "  "
+	if cm.marked[index] {
+		if chrome.plainUI {
+			mark = "* "
+		} else {
+			mark = "✓ "
+		}
+	}
+	label = mark + label
+	if selected {
+		return renderManagerSelectedRow(width, label, chrome, styles)
+	}
+	return lipgloss.NewStyle().Background(chrome.baseBg).Foreground(chrome.text).Width(width).Padding(0, 1).Render(truncate(label, max(1, width-2)))
+}
+
+func (cm ContactManager) statusLine(width int, chrome managerChrome) string {
+	if cm.statusMsg == "" {
+		return ""
+	}
+	fg := chrome.successFg
+	if cm.isErr {
+		fg = chrome.errorFg
+	}
+	return lipgloss.NewStyle().Background(chrome.baseBg).Foreground(fg).Width(width).Padding(0, 1).Render(cm.statusMsg)
+}
+
+func (cm ContactManager) viewForm(width, height int, chrome managerChrome, title string) string {
+	header := renderManagerHeader(title, width, chrome)
+	field := func(lbl string, in textinput.Model, focused bool) string {
+		labelW := clamp(width/5, 8, 14)
+		fieldW := max(8, width-labelW)
+		bg := chrome.fieldBg
+		if !focused {
+			bg = chrome.surfaceBg
+		}
+		left := lipgloss.NewStyle().Background(chrome.baseBg).Foreground(chrome.muted).Width(labelW).Padding(0, 1).Render(lbl)
+		right := lipgloss.NewStyle().Background(bg).Foreground(chrome.text).Width(fieldW).Padding(0, 1).Render(truncateStyled(inputViewWithCursor(in, focused), max(1, fieldW-2), bg))
+		return lipgloss.JoinHorizontal(lipgloss.Left, left, right)
+	}
+	rows := []string{
+		field("Name", cm.nameInput, !cm.focusEmail),
+		lipgloss.NewStyle().Background(chrome.baseBg).Width(width).Render(""),
+		field("Email", cm.emailInput, cm.focusEmail),
+	}
+	bodyH := max(1, height-lipgloss.Height(header)-4)
+	body := clampView(lipgloss.NewStyle().Background(chrome.baseBg).Width(width).Render(strings.Join(rows, "\n")), width, bodyH, chrome.baseBg)
+	parts := []string{header, body}
+	if status := cm.statusLine(width, chrome); status != "" {
+		parts = append(parts, status)
+	}
+	parts = append(parts, renderManagerActions(width, chrome, "enter", "save", "tab", "next field", "esc", "cancel"))
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+func (cm ContactManager) viewConfirmDelete(width int, chrome managerChrome) string {
+	header := renderManagerHeader("DELETE CONTACT?", width, chrome)
+	prompt := "Delete this contact?"
+	if ids := cm.targetIndexes(); len(ids) > 1 {
+		prompt = fmt.Sprintf("Delete %d selected contacts?", len(ids))
+	} else if c, ok := cm.selected(); ok {
+		prompt = fmt.Sprintf("Delete %q from your contacts?", c.Addr)
+	}
+	body := lipgloss.NewStyle().Background(chrome.baseBg).Foreground(chrome.text).Width(width).Padding(1, 2).Render(prompt)
+	actions := renderManagerActions(width, chrome, "y", "delete", "esc", "cancel")
+	return lipgloss.JoinVertical(lipgloss.Left, header, body, actions)
+}
+
+func (cm ContactManager) viewPicker(width, height int, chrome managerChrome, styles Styles) string {
+	header := renderManagerHeader("ADD FROM MAIL", width, chrome)
+	filterW := max(8, width-2)
+	filterLine := lipgloss.NewStyle().Background(chrome.fieldBg).Foreground(chrome.text).Width(filterW).Padding(0, 1).
+		Render(truncateStyled(inputViewWithCursor(cm.filter, true), max(1, filterW-2), chrome.fieldBg))
+	filtered := cm.filteredSeen()
+	anchor := cm.pickCursor
+	lines := make([]string, 0, max(1, len(filtered)))
+	if len(filtered) == 0 {
+		lines = append(lines, lipgloss.NewStyle().Background(chrome.baseBg).Foreground(chrome.muted).Width(width).Padding(0, 1).Render("No matching addresses."))
+	} else {
+		for i, c := range filtered {
+			lines = append(lines, cm.renderPickerRow(width, chrome, styles, c, i == cm.pickCursor))
+		}
+	}
+	bodyH := max(1, height-lipgloss.Height(header)-lipgloss.Height(filterLine)-4)
+	offset := settingsScrollOffset(len(lines), anchor, bodyH)
+	end := min(len(lines), offset+bodyH)
+	body := clampView(lipgloss.NewStyle().Background(chrome.baseBg).Width(width).Render(strings.Join(lines[offset:end], "\n")), width, bodyH, chrome.baseBg)
+	parts := []string{header, filterLine, body}
+	if status := cm.statusLine(width, chrome); status != "" {
+		parts = append(parts, status)
+	}
+	parts = append(parts, renderManagerActions(width, chrome, "space", "select", "enter", "add", "esc", "cancel"))
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+func (cm ContactManager) renderPickerRow(width int, chrome managerChrome, styles Styles, c db.Contact, selected bool) string {
+	label := c.Addr
+	if c.DisplayName != "" {
+		label = fmt.Sprintf("%s  <%s>", c.DisplayName, c.Addr)
+	}
+	mark := "  "
+	if idx := cm.seenIndex(c); idx >= 0 && cm.pickMarked[idx] {
+		if chrome.plainUI {
+			mark = "* "
+		} else {
+			mark = "✓ "
+		}
+	}
+	label = mark + label
+	if selected {
+		return renderManagerSelectedRow(width, label, chrome, styles)
+	}
+	return lipgloss.NewStyle().Background(chrome.baseBg).Foreground(chrome.text).Width(width).Padding(0, 1).Render(truncate(label, max(1, width-2)))
+}
+
+func (cm ContactManager) viewFilePicker(width, height int, chrome managerChrome) string {
+	title := "EXPORT CONTACTS"
+	if cm.importing {
+		title = "IMPORT CONTACTS"
+	}
+	header := renderManagerHeader(title, width, chrome)
+	dirLine := lipgloss.NewStyle().
+		Background(chrome.baseBg).
+		Foreground(chrome.muted).
+		Width(width).
+		Padding(0, 2).
+		Render(clampView(cm.filePicker.currentDir, width-2, 1, chrome.baseBg))
+
+	listH := max(1, height-lipgloss.Height(header)-lipgloss.Height(dirLine)-3)
+	start := 0
+	if cm.filePicker.cursor >= listH {
+		start = cm.filePicker.cursor - listH + 1
+	}
+	end := min(start+listH, len(cm.filePicker.entries))
+	visible := cm.filePicker.entries[start:end]
+
+	var rows []string
+	for i, entry := range visible {
+		idx := start + i
+		selected := idx == cm.filePicker.cursor
+		label := contactFileEntryLabel(entry)
+		style := lipgloss.NewStyle().Background(chrome.baseBg).Foreground(chrome.text).Width(width).Padding(0, 2)
+		if selected {
+			style = style.Background(chrome.accent).Foreground(contrastFg(chrome.accent))
+		} else if entry.isDir {
+			style = style.Foreground(chrome.accent)
+		} else if entry.name == "✓ select this folder" {
+			style = style.Foreground(chrome.successFg)
+		}
+		rows = append(rows, style.Render(clampView(label, max(1, width-4), 1, chrome.baseBg)))
+	}
+	for len(rows) < listH {
+		rows = append(rows, lipgloss.NewStyle().Background(chrome.baseBg).Width(width).Padding(0, 2).Render(""))
+	}
+	body := lipgloss.JoinVertical(lipgloss.Left, rows...)
+
+	parts := []string{header, dirLine, body}
+	if status := cm.statusLine(width, chrome); status != "" {
+		parts = append(parts, status)
+	}
+	action := "open/import"
+	if !cm.importing {
+		action = "open/export"
+	}
+	parts = append(parts, renderManagerActions(width, chrome, "enter", action, "←", "parent", "esc", "cancel"))
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+func contactFileEntryLabel(entry fileEntry) string {
+	switch {
+	case entry.name == "✓ select this folder":
+		return entry.name
+	case entry.isDir && entry.name == "..":
+		return "📁 ../"
+	case entry.isDir:
+		return "📁 " + entry.name
+	default:
+		return "📄 " + entry.name
+	}
+}

--- a/internal/ui/contact_manager_test.go
+++ b/internal/ui/contact_manager_test.go
@@ -1,0 +1,208 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/allisonhere/tide/internal/db"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func rune1(r rune) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}} }
+
+func newContactTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	for _, stmt := range []string{
+		"DELETE FROM attachments",
+		"DELETE FROM messages",
+		"DELETE FROM mailboxes",
+		"DELETE FROM accounts",
+		"DELETE FROM contacts",
+	} {
+		if _, err := database.Exec(stmt); err != nil {
+			t.Fatalf("reset db with %q: %v", stmt, err)
+		}
+	}
+	t.Cleanup(func() { database.Close() })
+	return database
+}
+
+func TestContactManagerAddContact(t *testing.T) {
+	d := newContactTestDB(t)
+	cm := NewContactManager(d)
+
+	cm, _, _ = cm.Update(rune1('n'), DefaultKeys)
+	if cm.mode != cmAdd {
+		t.Fatalf("expected add mode, got %v", cm.mode)
+	}
+	cm.nameInput.SetValue("Dave")
+	cm, _, _ = cm.Update(tea.KeyMsg{Type: tea.KeyTab}, DefaultKeys)
+	cm.emailInput.SetValue("DAVE@example.com")
+	cm, _, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter}, DefaultKeys)
+
+	if cm.mode != cmList {
+		t.Fatalf("expected return to list, got %v", cm.mode)
+	}
+	addrs, _ := d.ContactAddresses()
+	if len(addrs) != 1 || addrs[0] != "Dave <dave@example.com>" {
+		t.Fatalf("manual contact not in autocomplete: %v", addrs)
+	}
+}
+
+func TestContactManagerListScrolls(t *testing.T) {
+	d := newContactTestDB(t)
+	for i := 0; i < 40; i++ {
+		if _, err := d.AddContact(fmt.Sprintf("c%02d@example.com", i), "", "manual"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cm := NewContactManager(d)
+	if len(cm.contacts) != 40 {
+		t.Fatalf("setup: contacts=%d", len(cm.contacts))
+	}
+
+	const w, h = 60, 12
+	top := ansi.Strip(cm.View(w, h, BuildStyles(CatppuccinMocha, "compact")))
+	last := cm.contacts[len(cm.contacts)-1].Addr
+	if strings.Contains(top, last) {
+		t.Fatalf("last contact should not be visible before scrolling:\n%s", top)
+	}
+
+	for i := 0; i < len(cm.contacts)-1; i++ {
+		cm, _, _ = cm.Update(tea.KeyMsg{Type: tea.KeyDown}, DefaultKeys)
+	}
+	bottom := ansi.Strip(cm.View(w, h, BuildStyles(CatppuccinMocha, "compact")))
+	if !strings.Contains(bottom, last) {
+		t.Fatalf("selected last contact not visible after scrolling:\n%s", bottom)
+	}
+	if strings.Contains(bottom, cm.contacts[0].Addr) {
+		t.Fatalf("first contact should have scrolled off:\n%s", bottom)
+	}
+}
+
+func TestContactManagerBulkDelete(t *testing.T) {
+	d := newContactTestDB(t)
+	for i := 0; i < 3; i++ {
+		if _, err := d.AddContact(fmt.Sprintf("a%d@example.com", i), "", "manual"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cm := NewContactManager(d)
+	cm, _, _ = cm.Update(tea.KeyMsg{Type: tea.KeySpace}, DefaultKeys)
+	cm, _, _ = cm.Update(tea.KeyMsg{Type: tea.KeySpace}, DefaultKeys)
+	if len(cm.marked) != 2 {
+		t.Fatalf("expected 2 marked, got %d", len(cm.marked))
+	}
+	cm, _, _ = cm.Update(rune1('d'), DefaultKeys)
+	if cm.mode != cmConfirmDelete {
+		t.Fatalf("expected confirm-delete mode, got %v", cm.mode)
+	}
+	cm, _, _ = cm.Update(rune1('y'), DefaultKeys)
+
+	if len(cm.contacts) != 1 {
+		t.Fatalf("expected 1 remaining contact after bulk delete, got %d", len(cm.contacts))
+	}
+	if addrs, _ := d.ContactAddresses(); len(addrs) != 1 {
+		t.Fatalf("expected 1 autocomplete address after delete, got %v", addrs)
+	}
+}
+
+func TestContactManagerPickerAddsSeenAddresses(t *testing.T) {
+	d := newContactTestDB(t)
+	accountID, _ := d.AddAccount("Acct", "")
+	mailboxID, _ := d.UpsertMailbox(db.Mailbox{AccountID: accountID, Name: "INBOX"})
+	_ = d.UpsertMessage(db.Message{
+		MailboxID: mailboxID,
+		UID:       1,
+		From:      "Carol <carol@example.com>",
+		To:        "Alice <alice@example.com>, bob@example.com",
+	})
+	_, _ = d.AddContact("alice@example.com", "Alice", "manual")
+
+	cm := NewContactManager(d)
+	cm, _, _ = cm.Update(rune1('f'), DefaultKeys)
+	if cm.mode != cmPickSeen {
+		t.Fatalf("expected picker mode, got %v", cm.mode)
+	}
+	cm, _, _ = cm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("caro"), Paste: true}, DefaultKeys)
+	if len(cm.filteredSeen()) != 1 || cm.filteredSeen()[0].Addr != "carol@example.com" {
+		t.Fatalf("filter did not narrow to carol: %+v", cm.filteredSeen())
+	}
+	cm, _, _ = cm.Update(tea.KeyMsg{Type: tea.KeySpace}, DefaultKeys)
+	cm, _, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter}, DefaultKeys)
+
+	addrs, _ := d.ContactAddresses()
+	if len(addrs) != 2 || addrs[0] != "Alice <alice@example.com>" || addrs[1] != "Carol <carol@example.com>" {
+		t.Fatalf("picker did not add carol to contacts: %v", addrs)
+	}
+}
+
+func TestContactManagerImportsVCardThroughFilePicker(t *testing.T) {
+	d := newContactTestDB(t)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, "contacts.vcf")
+	if err := os.WriteFile(path, []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nFN:Imported Person\r\nEMAIL:imported@example.com\r\nEND:VCARD\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cm := NewContactManager(d)
+	cm, _, _ = cm.Update(rune1('i'), DefaultKeys)
+	if cm.mode != cmPickFile {
+		t.Fatalf("expected file picker mode, got %v", cm.mode)
+	}
+	cm, _, _ = cm.Update(rune1('c'), DefaultKeys)
+	cm, _, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter}, DefaultKeys)
+
+	addrs, _ := d.ContactAddresses()
+	if len(addrs) != 1 || addrs[0] != "Imported Person <imported@example.com>" {
+		t.Fatalf("import picker did not add contact: %v", addrs)
+	}
+}
+
+func TestContactManagerExportsVCardThroughFolderPicker(t *testing.T) {
+	d := newContactTestDB(t)
+	_, _ = d.AddContact("exported@example.com", "Exported Person", "manual")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	downloads := filepath.Join(home, "Downloads")
+	if err := os.MkdirAll(downloads, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cm := NewContactManager(d)
+	cm, _, _ = cm.Update(rune1('x'), DefaultKeys)
+	if cm.mode != cmPickFile {
+		t.Fatalf("expected folder picker mode, got %v", cm.mode)
+	}
+	cm, _, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter}, DefaultKeys)
+
+	data, err := os.ReadFile(filepath.Join(downloads, "contacts.vcf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "exported@example.com") {
+		t.Fatalf("exported vcard missing contact:\n%s", string(data))
+	}
+}
+
+func TestContactManagerEscExits(t *testing.T) {
+	d := newContactTestDB(t)
+	cm := NewContactManager(d)
+	_, _, exit := cm.Update(tea.KeyMsg{Type: tea.KeyEsc}, DefaultKeys)
+	if !exit {
+		t.Fatal("esc should exit the contact manager")
+	}
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -65,6 +65,7 @@ func renderHelp(width int, styles Styles, keys KeyMap) string {
 				{keys.Sync.Help().Key + " (on Unified)", "sync all inboxes"},
 				bind(keys.SyncAll),
 				bind(keys.AccountManager),
+				bind(keys.ContactManager),
 				{keys.Add.Help().Key, "add account"},
 				{keys.Edit.Help().Key, "edit account"},
 				{keys.Delete.Help().Key, "delete account"},

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -29,6 +29,7 @@ type KeyMap struct {
 	Command     key.Binding
 
 	AccountManager key.Binding
+	ContactManager key.Binding
 	ThemePicker    key.Binding
 	Settings       key.Binding
 	UpdateInstall  key.Binding
@@ -94,6 +95,7 @@ var DefaultKeys = KeyMap{
 	Command:     key.NewBinding(key.WithKeys("p", ":"), key.WithHelp("p", "command")),
 
 	AccountManager: key.NewBinding(key.WithKeys("M"), key.WithHelp("M", "accounts")),
+	ContactManager: key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "contacts")),
 	ThemePicker:    key.NewBinding(key.WithKeys("T"), key.WithHelp("T", "theme picker")),
 	Settings:       key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "settings")),
 	UpdateInstall:  key.NewBinding(key.WithKeys("U"), key.WithHelp("U", "install update")),

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -56,6 +56,7 @@ const (
 	overlaySearch
 	overlayThemePicker
 	overlayAccountManager
+	overlayContactManager
 	overlayHelp
 	overlaySettings
 	overlayUpdateConfirm
@@ -152,6 +153,7 @@ type Model struct {
 	themeCursor    int
 
 	accountManager AccountManager
+	contactManager ContactManager
 	compose        ComposeModel
 	addressBook    []string
 
@@ -512,8 +514,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Auto-sync: log to buffer silently (no status bar spam).
 			m.addToLog(fmt.Sprintf("auto-synced %d new (%v)", msg.NewCount, msg.Total.Round(time.Millisecond)), false)
 		}
-		if msg.NewCount > 0 && !msg.Manual {
-			cmds = append(cmds, m.notifyCmd(msg.MailboxID, msg.NewCount))
+		if len(msg.NewMessages) > 0 && !msg.Manual && m.cfg.Display.Notifications {
+			cmds = append(cmds, m.notifyCmd(msg.MailboxID, msg.NewMessages))
 		}
 		cmds = append(cmds, m.loadAddressBookCmd())
 		return m, tea.Batch(cmds...)
@@ -775,6 +777,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.overlay == overlayAccountManager {
 			return m.handleAccountManager(msg)
 		}
+		if m.overlay == overlayContactManager {
+			return m.handleContactManager(msg)
+		}
 		if m.overlay == overlaySettings {
 			return m.handleSettings(msg)
 		}
@@ -812,6 +817,11 @@ func (m Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case keyMatches(msg, m.keys.AccountManager):
 		m.overlay = overlayAccountManager
 		m.accountManager = m.newAccountManager()
+		return m, nil
+
+	case keyMatches(msg, m.keys.ContactManager):
+		m.overlay = overlayContactManager
+		m.contactManager = NewContactManager(m.db)
 		return m, nil
 
 	case keyMatches(msg, m.keys.ThemePicker):
@@ -1321,6 +1331,9 @@ func (m Model) handleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case overlayAccountManager:
 		return m.handleAccountManager(msg)
 
+	case overlayContactManager:
+		return m.handleContactManager(msg)
+
 	case overlayCompose:
 		return m.handleCompose(msg)
 
@@ -1545,6 +1558,17 @@ func (m Model) handleAccountManager(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if exit {
 		m.overlay = overlayNone
 		return m, m.loadAccountsCmd()
+	}
+	return m, cmd
+}
+
+func (m Model) handleContactManager(msg tea.Msg) (tea.Model, tea.Cmd) {
+	newCM, cmd, exit := m.contactManager.Update(msg, m.keys)
+	m.contactManager = newCM
+	if exit {
+		m.overlay = overlayNone
+		// Refresh autocomplete: edits in the manager change suggestions.
+		return m, m.loadAddressBookCmd()
 	}
 	return m, cmd
 }

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -21,11 +21,12 @@ type MessagesLoadedMsg struct {
 }
 
 type MailboxSyncedMsg struct {
-	MailboxID int64
-	NewCount  int
-	Err       error
-	Manual    bool
-	Total     time.Duration
+	MailboxID   int64
+	NewCount    int
+	NewMessages []db.Message // genuinely-new unread mail, for notification sender/subject
+	Err         error
+	Manual      bool
+	Total       time.Duration
 }
 
 type AccountSavedMsg struct {

--- a/internal/ui/notify_test.go
+++ b/internal/ui/notify_test.go
@@ -1,0 +1,122 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/allisonhere/tide/internal/db"
+)
+
+// A re-fetch of an already-stored UID (IMAP SINCE is date-granular) must not be
+// reported as new again — otherwise every poll re-notifies for the same mail.
+func TestStoreFetchedMessagesDeduplicatesByUID(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("Open DB: %v", err)
+	}
+	defer database.Close()
+
+	accountID, err := database.AddAccount("Personal", "")
+	if err != nil {
+		t.Fatalf("AddAccount: %v", err)
+	}
+	mailboxID, err := database.UpsertMailbox(db.Mailbox{AccountID: accountID, Name: "INBOX"})
+	if err != nil {
+		t.Fatalf("UpsertMailbox: %v", err)
+	}
+
+	msg := db.Message{UID: 7, From: "a@b.com", Subject: "Hi"}
+
+	first, err := storeFetchedMessages(database, mailboxID, []db.Message{msg})
+	if err != nil {
+		t.Fatalf("first store: %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("first fetch: expected 1 new, got %d", len(first))
+	}
+
+	// Same UID re-fetched: the upsert updates the row but it is not new mail.
+	second, err := storeFetchedMessages(database, mailboxID, []db.Message{msg})
+	if err != nil {
+		t.Fatalf("second store: %v", err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("re-fetch: expected 0 new, got %d", len(second))
+	}
+}
+
+// Already-read mail (e.g. read on another device) is stored but is not a new arrival.
+func TestStoreFetchedMessagesIgnoresRead(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("Open DB: %v", err)
+	}
+	defer database.Close()
+
+	accountID, _ := database.AddAccount("Personal", "")
+	mailboxID, _ := database.UpsertMailbox(db.Mailbox{AccountID: accountID, Name: "INBOX"})
+
+	newMsgs, err := storeFetchedMessages(database, mailboxID, []db.Message{{UID: 9, Read: true, Subject: "Seen"}})
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if len(newMsgs) != 0 {
+		t.Fatalf("expected read mail to count as 0 new, got %d", len(newMsgs))
+	}
+}
+
+func TestComposeNotificationSingle(t *testing.T) {
+	title, body := composeNotification("Work", []db.Message{
+		{From: "Jane Doe <jane@example.com>", Subject: "Lunch?"},
+	})
+	if title != "Jane Doe · Work" {
+		t.Fatalf("title = %q", title)
+	}
+	if body != "Lunch?" {
+		t.Fatalf("body = %q", body)
+	}
+}
+
+func TestComposeNotificationSingleFallbacks(t *testing.T) {
+	// No display name -> bare address; empty subject -> placeholder; no account -> no suffix.
+	title, body := composeNotification("", []db.Message{
+		{From: "noreply@example.com", Subject: "   "},
+	})
+	if title != "noreply@example.com" {
+		t.Fatalf("title = %q", title)
+	}
+	if body != "(no subject)" {
+		t.Fatalf("body = %q", body)
+	}
+}
+
+func TestComposeNotificationBatchCapsAndEscapes(t *testing.T) {
+	msgs := make([]db.Message, 7)
+	for i := range msgs {
+		msgs[i] = db.Message{From: "x@y.com", Subject: "Sub"}
+	}
+	// One sender carries markup-significant chars that must be escaped.
+	msgs[0] = db.Message{From: "A & B <ab@y.com>", Subject: "<tag>"}
+
+	title, body := composeNotification("Acct", msgs)
+	if !strings.HasPrefix(title, "7 new messages") {
+		t.Fatalf("title = %q", title)
+	}
+	if strings.Contains(body, "<tag>") || strings.Contains(body, "A & B") {
+		t.Fatalf("body not escaped: %q", body)
+	}
+	if !strings.Contains(body, "&amp;") || !strings.Contains(body, "&lt;tag&gt;") {
+		t.Fatalf("expected escaped entities in body: %q", body)
+	}
+	if !strings.Contains(body, "…and 2 more") {
+		t.Fatalf("expected overflow line, got: %q", body)
+	}
+	// 5 capped lines + 1 overflow line.
+	if got := strings.Count(body, "\n") + 1; got != 6 {
+		t.Fatalf("expected 6 body lines, got %d", got)
+	}
+}

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -53,6 +53,14 @@ func (m Model) renderOverlay(base string) string {
 		inner = clampView(inner, winW, strings.Count(inner, "\n")+1, chrome.baseBg)
 		box = renderChromeOverlayBox(inner, winW, chrome, chrome.accent)
 
+	case overlayContactManager:
+		winW := min(m.width-4, 74)
+		winH := min(m.height-4, 40)
+		chrome := newManagerChrome(winW, m.styles.Theme, m.styles.PlainUI)
+		inner := m.contactManager.View(winW, winH, m.styles)
+		inner = clampView(inner, winW, strings.Count(inner, "\n")+1, chrome.baseBg)
+		box = renderChromeOverlayBox(inner, winW, chrome, chrome.accent)
+
 	case overlayCompose:
 		winW := min(m.width-4, 74)
 		winH := min(m.height-4, 36)

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -66,6 +66,7 @@ const (
 	sfTheme
 	sfConfirmQuit
 	sfShowHeaders
+	sfNotifications
 	// sfBackToSections is the first focusable target in the detail pane.
 	// Activating it restores focus to the sidebar so users never auto-land on a text input.
 	sfBackToSections
@@ -222,6 +223,7 @@ type Settings struct {
 	filterLinks          bool
 	confirmQuit          bool
 	showHeaders          bool
+	notifications        bool
 	layoutDensityIdx     int // 0 = comfortable, 1 = compact
 	readingWidthInput    textinput.Model
 	browserInput         textinput.Model
@@ -310,6 +312,7 @@ func newSettings(cfg config.Config, updateState settingsUpdateState) Settings {
 		filterLinks:          cfg.Display.FilterLinks,
 		confirmQuit:          cfg.Display.ConfirmQuit,
 		showHeaders:          cfg.Display.ShowHeaders,
+		notifications:        cfg.Display.Notifications,
 		layoutDensityIdx:     layoutIdx,
 		readingWidthInput:    mkInput(strconv.Itoa(cfg.Display.ReadingWidth), "0 (no limit)", false),
 		browserInput:         mkInput(cfg.Display.Browser, "xdg-open", false),
@@ -373,6 +376,7 @@ func (s Settings) ApplyTo(cfg config.Config) config.Config {
 	cfg.Display.FilterLinks = s.filterLinks
 	cfg.Display.ConfirmQuit = s.confirmQuit
 	cfg.Display.ShowHeaders = s.showHeaders
+	cfg.Display.Notifications = s.notifications
 	if w, err := strconv.Atoi(strings.TrimSpace(s.readingWidthInput.Value())); err == nil {
 		cfg.Display.ReadingWidth = max(0, w)
 	}
@@ -589,7 +593,7 @@ func (s Settings) sectionFields(section settingsSection) []settingsField {
 		if config.IsRetroTerminalTheme(s.themeName) {
 			fields = append(fields, sfRetroBg, sfRetroFg, sfRetroAccent)
 		}
-		return append(fields, sfActionableLinks, sfFilterLinks, sfBrowser, sfConfirmQuit, sfShowHeaders)
+		return append(fields, sfActionableLinks, sfFilterLinks, sfBrowser, sfConfirmQuit, sfShowHeaders, sfNotifications)
 	case ssFeeds:
 		return []settingsField{sfBackToSections, sfFeedMaxBody}
 	case ssUpdates:
@@ -1080,6 +1084,15 @@ func (s Settings) Update(msg tea.Msg, keys KeyMap) (Settings, tea.Cmd, bool) {
 			s.setFocusedField(s.prevField())
 		}
 
+	case sfNotifications:
+		if keyMatches(key, keys.Space) || keyMatches(key, keys.Enter) {
+			s.notifications = !s.notifications
+		} else if keyMatches(key, keys.Down) {
+			s.setFocusedField(s.nextField())
+		} else if keyMatches(key, keys.Up) {
+			s.setFocusedField(s.prevField())
+		}
+
 	case sfMarkReadOnSummarize:
 		if keyMatches(key, keys.Space) || keyMatches(key, keys.Enter) {
 			s.markReadOnSummarize = !s.markReadOnSummarize
@@ -1432,6 +1445,7 @@ func (s Settings) viewSectionBody(width int, chrome managerChrome) settingsSecti
 		b.addInput("Browser command", s.browserInput, sfBrowser)
 		b.addToggle("Confirm before quitting", s.confirmQuit, sfConfirmQuit)
 		b.addToggle("Show email headers", s.showHeaders, sfShowHeaders)
+		b.addToggle("Desktop notifications", s.notifications, sfNotifications)
 
 	case ssFeeds:
 		b.addGroup("Storage")
@@ -2269,6 +2283,8 @@ func (s Settings) fieldHint(field settingsField) string {
 		return "strip bare URLs from the article body text"
 	case sfFocusLine:
 		return "highlight the current readable line in the content pane"
+	case sfNotifications:
+		return "show a desktop notification when new mail arrives during background sync"
 	case sfUpdateManualCommand:
 		return "enter or c copies the command"
 	default:

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -17,9 +17,9 @@ func TestSettingsFieldNavigationClampsAtEnds(t *testing.T) {
 	s := newSettings(config.DefaultConfig(), settingsUpdateState{})
 	s.setActiveSection(ssDisplay)
 	s.setFocusedPane(settingsPaneDetail)
-	s.setFocusedField(sfShowHeaders)
-	if got := s.nextField(); got != sfShowHeaders {
-		t.Fatalf("nextField at last visible field: got %v want sfShowHeaders", got)
+	s.setFocusedField(sfNotifications)
+	if got := s.nextField(); got != sfNotifications {
+		t.Fatalf("nextField at last visible field: got %v want sfNotifications", got)
 	}
 	s.setFocusedField(sfBackToSections)
 	if got := s.prevField(); got != sfBackToSections {
@@ -187,6 +187,26 @@ func TestSettingsLoadsAndAppliesMarkReadOnFocus(t *testing.T) {
 	next := s.ApplyTo(cfg)
 	if next.Display.MarkReadOnFocus {
 		t.Fatal("expected ApplyTo to save disabled mark-read-on-focus")
+	}
+}
+
+func TestSettingsLoadsAndAppliesNotifications(t *testing.T) {
+	if !config.DefaultConfig().Display.Notifications {
+		t.Fatal("expected notifications to default on")
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Display.Notifications = false
+
+	s := newSettings(cfg, settingsUpdateState{})
+	if s.notifications {
+		t.Fatal("expected settings to load disabled notifications from config")
+	}
+
+	s.notifications = true
+	next := s.ApplyTo(cfg)
+	if !next.Display.Notifications {
+		t.Fatal("expected ApplyTo to save enabled notifications")
 	}
 }
 

--- a/internal/ui/sync.go
+++ b/internal/ui/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/mail"
 	"os"
 	"os/exec"
 	"strings"
@@ -105,28 +106,83 @@ func (m *Model) loadUnifiedInboxCmd() tea.Cmd {
 func (m *Model) loadAddressBookCmd() tea.Cmd {
 	database := m.db
 	return func() tea.Msg {
-		addrs, err := database.ListAddresses()
+		addrs, err := database.ContactAddresses()
 		return AddressBookLoadedMsg{Addresses: addrs, Err: err}
 	}
 }
 
-func (m *Model) notifyCmd(mailboxID int64, newCount int) tea.Cmd {
+func (m *Model) notifyCmd(mailboxID int64, newMsgs []db.Message) tea.Cmd {
 	database := m.db
 	return func() tea.Msg {
-		mailbox, err := database.GetMailbox(mailboxID)
-		if err != nil {
-			return nil
+		// Account name gives multi-account context; best-effort, not required.
+		var acctName string
+		if mailbox, err := database.GetMailbox(mailboxID); err == nil {
+			if acc, err := database.GetAccount(mailbox.AccountID); err == nil {
+				acctName = acc.Name
+			}
 		}
-		acc, err := database.GetAccount(mailbox.AccountID)
-		if err != nil {
-			return nil
-		}
+		title, body := composeNotification(acctName, newMsgs)
 		// notify-send is fire-and-forget; exec the non-interactive version.
-		title := acc.Name
-		body := fmt.Sprintf("%s — %d new", mailbox.DisplayName, newCount)
 		_ = exec.Command("notify-send", "-a", "tidemail", "-i", "mail-unread", title, body).Run()
 		return nil
 	}
+}
+
+// composeNotification builds the title/body for a new-mail desktop notification:
+// one message shows "sender" / "subject"; a batch shows "N new messages" with a
+// capped "sender — subject" list. All dynamic text is single-lined and markup-escaped.
+func composeNotification(acctName string, msgs []db.Message) (title, body string) {
+	const maxLines = 5
+	suffix := ""
+	if acctName != "" {
+		suffix = " · " + notifyEscape(acctName)
+	}
+	if len(msgs) == 1 {
+		return notifyEscape(senderDisplay(msgs[0].From)) + suffix, notifyEscape(subjectOrDefault(msgs[0].Subject))
+	}
+	title = fmt.Sprintf("%d new messages", len(msgs)) + suffix
+	lines := make([]string, 0, maxLines+1)
+	for i, msg := range msgs {
+		if i >= maxLines {
+			lines = append(lines, fmt.Sprintf("…and %d more", len(msgs)-maxLines))
+			break
+		}
+		lines = append(lines, notifyEscape(senderDisplay(msg.From)+" — "+subjectOrDefault(msg.Subject)))
+	}
+	return title, strings.Join(lines, "\n")
+}
+
+// senderDisplay prefers the From header's display name, falling back to the bare
+// address (or the raw header if it doesn't parse). Newlines are collapsed so the
+// value never spans notification rows.
+func senderDisplay(from string) string {
+	from = strings.TrimSpace(from)
+	out := from
+	if addr, err := mail.ParseAddress(from); err == nil {
+		if name := strings.TrimSpace(addr.Name); name != "" {
+			out = name
+		} else {
+			out = addr.Address
+		}
+	}
+	return strings.Join(strings.Fields(out), " ")
+}
+
+func subjectOrDefault(subject string) string {
+	if s := strings.Join(strings.Fields(subject), " "); s != "" {
+		return s
+	}
+	return "(no subject)"
+}
+
+// notifyEscape escapes the GLib/Pango markup chars that notification daemons
+// (dunst, GNOME) interpret in body text, so untrusted sender/subject content can't
+// break or inject into the notification.
+func notifyEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
 }
 
 func (m *Model) scheduleNextSync(accountID int64) tea.Cmd {
@@ -207,7 +263,7 @@ func (m *Model) syncMailboxCmd(mailboxID int64, manual bool) tea.Cmd {
 			logFetch(acc.Name, mailbox.Name, 0, connectDur, fetchDur, time.Since(t0), err)
 			return MailboxSyncedMsg{MailboxID: mailboxID, Err: err, Manual: manual, Total: time.Since(t0)}
 		}
-		newCount, err := storeFetchedMessages(database, mailboxID, msgs)
+		newMsgs, err := storeFetchedMessages(database, mailboxID, msgs)
 		if err != nil {
 			logFetch(acc.Name, mailbox.Name, len(msgs), connectDur, fetchDur, time.Since(t0), err)
 			return MailboxSyncedMsg{MailboxID: mailboxID, Err: err, Manual: manual, Total: time.Since(t0)}
@@ -223,22 +279,28 @@ func (m *Model) syncMailboxCmd(mailboxID int64, manual bool) tea.Cmd {
 			writeErr = e
 		}
 		logFetch(acc.Name, mailbox.Name, len(msgs), connectDur, fetchDur, time.Since(t0), writeErr)
-		return MailboxSyncedMsg{MailboxID: mailboxID, NewCount: newCount, Manual: manual, Total: time.Since(t0)}
+		return MailboxSyncedMsg{MailboxID: mailboxID, NewCount: len(newMsgs), NewMessages: newMsgs, Manual: manual, Total: time.Since(t0)}
 	}
 }
 
-func storeFetchedMessages(database *db.DB, mailboxID int64, msgs []db.Message) (int, error) {
-	newCount := 0
+// storeFetchedMessages upserts msgs and returns the genuinely-new unread ones
+// (previously-unseen UIDs), used to drive desktop notifications. Callers derive the
+// "N new" count from len(newMsgs).
+func storeFetchedMessages(database *db.DB, mailboxID int64, msgs []db.Message) ([]db.Message, error) {
+	var newMsgs []db.Message
 	for _, msg := range msgs {
 		msg.MailboxID = mailboxID
+		// Determine novelty before the upsert: SINCE re-fetches mail we already hold,
+		// and the upsert would otherwise make every poll look like new arrivals.
+		existed, exErr := database.MessageExists(mailboxID, msg.UID)
 		if err := database.UpsertMessage(msg); err != nil {
-			return newCount, err
+			return newMsgs, err
 		}
-		if !msg.Read {
-			newCount++
+		if exErr == nil && !existed && !msg.Read {
+			newMsgs = append(newMsgs, msg)
 		}
 	}
-	return newCount, nil
+	return newMsgs, nil
 }
 
 func logFetch(account, mailbox string, msgCount int, connectDur, fetchDur, totalDur time.Duration, err error) {


### PR DESCRIPTION
## What changed

- Added a curated contacts data model, migrations, vCard import support, and database tests.
- Added a contact manager overlay and keyboard wiring for managing contacts in the UI.
- Updated autocomplete/address book loading to use curated contacts.
- Improved new-mail notification behavior so notifications are based on genuinely new unread messages and include sender/subject details.
- Included the related Hermes implementation notes.

## Validation

- `go test ./...`