### PR TITLE
Read the Omarchy install that actually exists

### DIFF
--- a/internal/omarchy/omarchy.go
+++ b/internal/omarchy/omarchy.go
@@ -38,45 +38,70 @@ type Palette struct {
 // resolverTimeout bounds the `omarchy-theme-color` subprocess.
 const resolverTimeout = 2 * time.Second
 
-// stateDir returns ~/.local/state/omarchy, honoring XDG_STATE_HOME.
-func stateDir() string {
-	if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
-		return filepath.Join(xdg, "omarchy")
+// roots returns the directories that may hold Omarchy's "current" state, most
+// authoritative first. Current releases stage the active theme under
+// ~/.local/state/omarchy, but installs predating that move keep it in
+// ~/.config/omarchy and are still live, so probing only the state root finds
+// nothing on those machines. OMARCHY_DIR overrides both for containers and
+// deterministic tests.
+func roots() []string {
+	if dir := strings.TrimSpace(os.Getenv("OMARCHY_DIR")); dir != "" {
+		return []string{dir}
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ""
+		return nil
 	}
-	return filepath.Join(home, ".local", "state", "omarchy")
+	stateHome := strings.TrimSpace(os.Getenv("XDG_STATE_HOME"))
+	if stateHome == "" {
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	configHome, err := os.UserConfigDir()
+	if err != nil {
+		configHome = filepath.Join(home, ".config")
+	}
+	return []string{filepath.Join(stateHome, "omarchy"), filepath.Join(configHome, "omarchy")}
 }
 
+// currentThemeDir returns the first root that actually stages a theme, so an
+// empty state root (Omarchy creates ~/.local/state/omarchy for unrelated
+// things like toggles/) does not shadow a populated config root.
 func currentThemeDir() string {
-	d := stateDir()
-	if d == "" {
-		return ""
+	for _, root := range roots() {
+		dir := filepath.Join(root, "current", "theme")
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
 	}
-	return filepath.Join(d, "current", "theme")
+	return ""
 }
 
 func themeNamePath() string {
-	d := stateDir()
-	if d == "" {
-		return ""
+	for _, root := range roots() {
+		p := filepath.Join(root, "current", "theme.name")
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
 	}
-	return filepath.Join(d, "current", "theme.name")
+	return ""
 }
 
 // currentThemeName reads the active theme slug, or "" if unavailable.
 func currentThemeName() string {
-	p := themeNamePath()
-	if p == "" {
-		return ""
+	if p := themeNamePath(); p != "" {
+		if b, err := os.ReadFile(p); err == nil {
+			if name := strings.TrimSpace(string(b)); name != "" {
+				return name
+			}
+		}
 	}
-	b, err := os.ReadFile(p)
-	if err != nil {
-		return ""
+	// No theme.name: the symlink target's basename is the slug.
+	if dir := currentThemeDir(); dir != "" {
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			return filepath.Base(resolved)
+		}
 	}
-	return strings.TrimSpace(string(b))
+	return ""
 }
 
 // CurrentSignature returns a token that changes whenever the active Omarchy
@@ -98,10 +123,17 @@ func CurrentSignature() string {
 			}
 		}
 	}
-	if name == "" && stamp == "" {
+	// Omarchy switches themes by repointing current/theme, which can leave
+	// theme.name's mtime untouched, so the link target has to be part of the
+	// token too or a switch goes unnoticed.
+	var target string
+	if dir := currentThemeDir(); dir != "" {
+		target, _ = filepath.EvalSymlinks(dir)
+	}
+	if name == "" && stamp == "" && target == "" {
 		return ""
 	}
-	return name + "@" + stamp
+	return name + "@" + stamp + "@" + target
 }
 
 // CurrentPalette locates the active Omarchy theme and parses its palette. ok is
@@ -185,12 +217,8 @@ func parseFlatTOML(s string) map[string]string {
 		if !found {
 			continue
 		}
-		key = strings.TrimSpace(key)
-		val = strings.Trim(strings.TrimSpace(val), `"'`)
-		// Drop a trailing inline comment on unquoted values.
-		if i := strings.IndexByte(val, '#'); i > 0 && !strings.HasPrefix(val, "#") {
-			val = strings.TrimSpace(val[:i])
-		}
+		key = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), "-", "_"))
+		val = tomlValue(val)
 		if key != "" && val != "" {
 			m[key] = val
 		}
@@ -227,13 +255,16 @@ func parsePalette(m map[string]string) (Palette, bool) {
 		Name:       get("name", "theme_name"),
 		Mode:       strings.ToLower(get("mode", "theme_type")),
 		Background: get("background", "bg", "color0"),
-		Foreground: get("foreground", "fg", "color7"),
+		Foreground: get("foreground", "text", "fg", "color7"),
 		Accent:     get("accent", "color4", "blue"),
-		Selection:  get("selection", "selection_background", "color8"),
-		Muted:      get("muted", "color8", "dark_foreground"),
-		StatusBg:   get("lighter_background", "dark_background", "color8"),
-		Error:      get("red", "color1"),
-		Ok:         get("green", "color2"),
+		// Omarchy's generated Kitty, Alacritty and Ghostty configs all resolve
+		// selection_background to the accent for semantic palettes; color8 is
+		// only right for older ANSI-only ones, so it is tried first.
+		Selection: get("selection", "selection_background", "color8", "accent"),
+		Muted:     get("muted", "color8", "dark_foreground"),
+		StatusBg:  get("lighter_background", "surface", "dark_background", "color8"),
+		Error:     get("danger", "red", "color1"),
+		Ok:        get("success", "green", "color2"),
 	}
 	if !isHex(p.Background) || !isHex(p.Foreground) {
 		return Palette{}, false
@@ -260,7 +291,7 @@ func parseAlacritty(s string) (Palette, bool) {
 			continue
 		}
 		key = strings.TrimSpace(key)
-		val = strings.Trim(strings.TrimSpace(val), `"'`)
+		val = tomlValue(val)
 		if section != "" && key != "" && val != "" {
 			vals[section+"."+key] = val
 		}
@@ -292,6 +323,24 @@ func inferMode(bgHex string) string {
 		return "light"
 	}
 	return "dark"
+}
+
+// tomlValue extracts a scalar from the right-hand side of a `key = value`
+// line. Every Omarchy color is a quoted hex string, so a comment stripper that
+// simply cuts at the first '#' erases the value itself; the quoted span is
+// taken first and only an unquoted remainder is scanned for a trailing
+// comment.
+func tomlValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) > 0 && (value[0] == '"' || value[0] == '\'') {
+		if end := strings.IndexByte(value[1:], value[0]); end >= 0 {
+			return value[1 : end+1]
+		}
+	}
+	if i := strings.Index(value, " #"); i >= 0 {
+		value = value[:i]
+	}
+	return strings.TrimSpace(value)
 }
 
 func firstNonEmpty(a, b string) string {

--- a/internal/omarchy/omarchy_test.go
+++ b/internal/omarchy/omarchy_test.go
@@ -187,3 +187,84 @@ green = "#40a02b"
 		t.Error("CurrentSignature should be non-empty when state exists")
 	}
 }
+
+// The format Omarchy actually ships: a [palette] section header with semantic
+// keys. The older tests here only covered background/foreground/red/green,
+// which no installed theme uses, so a resolver that could not read a single
+// real theme still passed them.
+func TestParseFlatTOMLRealSemanticPalette(t *testing.T) {
+	src := `[palette]
+bg = "#1a1b26"
+surface = "#272833"
+surface_alt = "#444b6a"
+text = "#a9b1d6"
+muted = "#686d86"
+accent = "#7aa2f7"
+accent_alt = "#449dab"
+danger = "#f7768e"
+success = "#9ece6a"
+warning = "#e0af68"
+shadow = "#0d0d13"
+`
+	p, ok := parsePalette(parseFlatTOML(src))
+	if !ok {
+		t.Fatal("real [palette] colors.toml did not parse")
+	}
+	for _, c := range []struct{ name, got, want string }{
+		{"background", p.Background, "#1a1b26"},
+		{"foreground", p.Foreground, "#a9b1d6"},
+		{"accent", p.Accent, "#7aa2f7"},
+		{"muted", p.Muted, "#686d86"},
+		{"statusbg", p.StatusBg, "#272833"},
+		{"error", p.Error, "#f7768e"},
+		{"ok", p.Ok, "#9ece6a"},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}
+
+// Every value is a hex color, so a comment stripper that cuts at the first '#'
+// deletes the color itself and the whole file parses as empty.
+func TestParseFlatTOMLKeepsHexPastInlineComment(t *testing.T) {
+	m := parseFlatTOML("bg = \"#1a1b26\" # page background\ntext = \"#a9b1d6\"\n")
+	if m["bg"] != "#1a1b26" {
+		t.Fatalf("bg = %q, want #1a1b26", m["bg"])
+	}
+}
+
+// ~/.local/state/omarchy exists on machines whose themes live in
+// ~/.config/omarchy (Omarchy puts toggles/ there regardless), so the state
+// root must not shadow a populated config root.
+func TestCurrentPaletteFallsBackToConfigRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("PATH", filepath.Join(home, "bin")) // no resolver on PATH
+
+	// An empty-but-present state root, as Omarchy leaves it.
+	if err := os.MkdirAll(filepath.Join(home, ".local", "state", "omarchy", "toggles"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	themeDir := filepath.Join(home, ".config", "omarchy", "current", "theme")
+	if err := os.MkdirAll(themeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "[palette]\nbg = \"#1a1b26\"\nsurface = \"#272833\"\ntext = \"#a9b1d6\"\naccent = \"#7aa2f7\"\n"
+	if err := os.WriteFile(filepath.Join(themeDir, "colors.toml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, ok := CurrentPalette()
+	if !ok {
+		t.Fatal("config-root theme not found while an empty state root exists")
+	}
+	if p.Background != "#1a1b26" || p.Foreground != "#a9b1d6" {
+		t.Fatalf("palette = %+v", p)
+	}
+	if CurrentSignature() == "" {
+		t.Fatal("signature empty for a resolvable config-root theme")
+	}
+}


### PR DESCRIPTION
`CurrentPalette` returned `ok=false` on a real Omarchy machine, so `match-omarchy` silently fell back to its placeholder palette and never followed the desktop. Because built-in themes have no resolution step, they all worked — which made this look like "the Omarchy theme does nothing" rather than a failure.

Three causes, all confirmed against upstream's own `omarchy-theme-set`:

```sh
CURRENT_THEME_PATH="$HOME/.config/omarchy/current/theme"
USER_THEMES_PATH="$HOME/.config/omarchy/themes"
echo "$THEME_NAME" > "$HOME/.config/omarchy/current/theme.name"
```

1. **Wrong root.** Nothing is staged under `~/.local/state/omarchy`, the only root probed. That directory *does* exist — Omarchy puts `toggles/` there — so a plain existence check found it and stopped. Both roots are now tried, most authoritative first, and a root only counts once it actually stages a theme. `OMARCHY_DIR` overrides both for containers and tests.

2. **Missing key.** Real themes use semantic `[palette]` keys. Foreground was read from `foreground`/`fg`/`color7` only, but themes spell it `text`, so the palette failed its background-and-foreground guard even when the file was found. Adds `text`, plus `danger`/`success`/`surface`.

3. **Comment stripper ate the colour.** Every value is a hex colour, so cutting at the first `#` deletes the value itself and the whole file parses as empty. `tomlValue` takes the quoted span first.

Also: `CurrentSignature` now includes the resolved symlink target. Omarchy switches themes by repointing `current/theme`, which can leave `theme.name`'s mtime untouched, so the live-follow poll could miss a switch.

Note there is no `omarchy-theme-color` binary in an Omarchy install — only `omarchy-theme-colors-from-alacritty`, which `omarchy-theme-set` calls to *generate* `colors.toml`. The resolver shell-out is left in place as a harmless no-op.

## Testing

The existing tests only covered `background`/`foreground`/`red`/`green`, which no installed theme uses — so a resolver that could not read a single real theme still passed them. Three new tests cover the real `[palette]` format, the hex-versus-comment trap, and an empty state root beside a populated config root. All three were confirmed to **fail** against the previous resolver and pass against this one.

Verified end to end on a real install: `CurrentPalette` now returns `#1a1b26 / #a9b1d6 / #7aa2f7` from `~/.config/omarchy/current/theme/colors.toml`, and `resolveOmarchyTheme` renders through the UI adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJBfwmoPKZGVB6CtCA2sEp