### PR TITLE
docs: add a What's new section and a release-time doc checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,19 @@ source under `content/tidemail/` when the change needs a user-facing guide or
 reference update, then run `npm run build` there so generated files stay in
 sync. If no documentation change is needed, briefly note why in the change
 summary.
+
+## At release time
+
+Three things name the current version and drift apart silently, because
+`deploy.sh` updates none of them. Do all three in the release commit:
+
+1. **`CHANGELOG.md`** — retitle the `## Unreleased` block to the version being
+   tagged, and open a fresh empty `## Unreleased` above it. Leaving shipped
+   entries under `Unreleased` means the next release announces them a second
+   time while its own work goes unannounced.
+2. **`README.md`** — rewrite the `## What's new in vX.Y.Z` section so its
+   heading and its bullets match the release just tagged. It describes what
+   someone gets from `install.sh`, so it must never list unreleased work.
+3. **`STATUS.md`** — update the `Current release:` line.
+
+The version in the tag is the source of truth; the other three follow it.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ _One inbox, several built-in themes.
   theme follows your current desktop theme — contrast-corrected to the same
   bar as the built-ins — and repaints live when you switch it.
 
+## What's new in v1.0.15
+
+- **Pane header bars are now optional.** Turn the title-and-shortcut row above
+  each pane off at **Settings → Display → Pane header bars** to give content more
+  room. The focused pane's title and shortcuts move to the status line, and each
+  pane gains a row.
+- **HTML mail keeps all of its content.** The old noise stripper could drop real
+  body sections, long messages, and the text inside tables and quoted replies.
+  Rendering now removes only what is genuinely hidden, plus tracking pixels, and
+  leaves document structure and message order alone.
+- **Triage no longer loses your place.** Deleting several messages in a row keeps
+  the focused row on the same line instead of snapping the list back to the top.
+
+Every release is listed in the [changelog](CHANGELOG.md).
+
 ## Install
 
 Linux and macOS builds are available for Intel and ARM machines.


### PR DESCRIPTION
The README had no record of what shipped recently, so a reader had to open the changelog to find out what changed. Adds a "What's new in v1.0.15" section between Highlights and Install, covering the three items that release carried.

It is scoped to released work on purpose: the section describes what someone gets from install.sh, so listing unreleased work would misdescribe the binary.

Also records the release-time step in AGENTS.md. CHANGELOG.md, README.md and STATUS.md each name the current version and deploy.sh updates none of them, so all three drift apart silently -- STATUS.md currently says v1.0.5 against a v1.0.15 tag, and the changelog still has shipped entries filed under Unreleased.


Claude-Session: https://claude.ai/code/session_01SPBQLtxu8G8UnrgHY4xq7y